### PR TITLE
ci: run release only for tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,8 @@ name: Publish Release
 
 on:
   push:
-    branches: [ main ]
     tags:
-      - "*"
+      - "v*"
 
 jobs:
   release:


### PR DESCRIPTION
Future releases will have to use the v prefix

