### PR TITLE
implement, document and test more checks for illegal arguments

### DIFF
--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/LineString.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/LineString.kt
@@ -14,24 +14,48 @@ import org.maplibre.spatialk.geojson.serialization.jsonProp
 import org.maplibre.spatialk.geojson.serialization.toBbox
 import org.maplibre.spatialk.geojson.serialization.toPosition
 
+/**
+ * @throws IllegalArgumentException if the coordinates contain less than two positions
+ */
 @Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
 @Serializable(with = GeometrySerializer::class)
 public class LineString
 @JvmOverloads
-constructor(public val coordinates: List<Position>, override val bbox: BoundingBox? = null) :
-    Geometry() {
+constructor(
+    /** a list of [Position]s. */
+    public val coordinates: List<Position>,
+    /** a bounding box */
+    override val bbox: BoundingBox? = null
+) : Geometry() {
+
+    /**
+     * Create a LineString by a number of [Position]s.
+     *
+     * @throws IllegalArgumentException if less than two coordinates have been specified
+     */
     @JvmOverloads
     public constructor(
         vararg coordinates: Position,
         bbox: BoundingBox? = null,
     ) : this(coordinates.toList(), bbox)
 
+    /**
+     * Create a LineString by the positions of a number of [Point]s.
+     *
+     * @throws IllegalArgumentException if less than two points have been specified
+     */
     @JvmOverloads
     public constructor(
         vararg points: Point,
         bbox: BoundingBox? = null,
     ) : this(points.map { it.coordinates }, bbox)
 
+    /**
+     * Create a LineString by an array of [DoubleArray]s that each represent a position.
+     *
+     * @throws IllegalArgumentException if the coordinates contain less than two positions or any
+     *   array of doubles does not represent a valid position
+     */
     @JvmOverloads
     public constructor(
         coordinates: Array<DoubleArray>,
@@ -39,7 +63,7 @@ constructor(public val coordinates: List<Position>, override val bbox: BoundingB
     ) : this(coordinates.map(::Position), bbox)
 
     init {
-        require(coordinates.size >= 2) { "LineString must have at least two positions" }
+        require(coordinates.size >= 2) { "LineString must contain at least two positions" }
     }
 
     override fun equals(other: Any?): Boolean {

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/LineString.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/LineString.kt
@@ -14,9 +14,7 @@ import org.maplibre.spatialk.geojson.serialization.jsonProp
 import org.maplibre.spatialk.geojson.serialization.toBbox
 import org.maplibre.spatialk.geojson.serialization.toPosition
 
-/**
- * @throws IllegalArgumentException if the coordinates contain less than two positions
- */
+/** @throws IllegalArgumentException if the coordinates contain fewer than two positions */
 @Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
 @Serializable(with = GeometrySerializer::class)
 public class LineString
@@ -25,13 +23,13 @@ constructor(
     /** a list of [Position]s. */
     public val coordinates: List<Position>,
     /** a bounding box */
-    override val bbox: BoundingBox? = null
+    override val bbox: BoundingBox? = null,
 ) : Geometry() {
 
     /**
      * Create a LineString by a number of [Position]s.
      *
-     * @throws IllegalArgumentException if less than two coordinates have been specified
+     * @throws IllegalArgumentException if fewer than two coordinates have been specified
      */
     @JvmOverloads
     public constructor(
@@ -42,7 +40,7 @@ constructor(
     /**
      * Create a LineString by the positions of a number of [Point]s.
      *
-     * @throws IllegalArgumentException if less than two points have been specified
+     * @throws IllegalArgumentException if fewer than two points have been specified
      */
     @JvmOverloads
     public constructor(
@@ -53,7 +51,7 @@ constructor(
     /**
      * Create a LineString by an array of [DoubleArray]s that each represent a position.
      *
-     * @throws IllegalArgumentException if the coordinates contain less than two positions or any
+     * @throws IllegalArgumentException if the coordinates contain fewer than two positions or any
      *   array of doubles does not represent a valid position
      */
     @JvmOverloads

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiLineString.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiLineString.kt
@@ -14,17 +14,13 @@ import org.maplibre.spatialk.geojson.serialization.jsonProp
 import org.maplibre.spatialk.geojson.serialization.toBbox
 import org.maplibre.spatialk.geojson.serialization.toPosition
 
-/**
- * @throws IllegalArgumentException if any of the position lists is not a valid line string
- */
+/** @throws IllegalArgumentException if any of the position lists is not a valid line string */
 @Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
 @Serializable(with = GeometrySerializer::class)
 public class MultiLineString
 @JvmOverloads
-constructor(
-    public val coordinates: List<List<Position>>,
-    override val bbox: BoundingBox? = null
-) : Geometry() {
+constructor(public val coordinates: List<List<Position>>, override val bbox: BoundingBox? = null) :
+    Geometry() {
 
     /**
      * Create a MultiLineString by a number of lists of [Position]s.
@@ -37,9 +33,7 @@ constructor(
         bbox: BoundingBox? = null,
     ) : this(coordinates.toList(), bbox)
 
-    /**
-     * Create a MultiLineString by a number of [LineString]s.
-     */
+    /** Create a MultiLineString by a number of [LineString]s. */
     @JvmOverloads
     public constructor(
         vararg lineStrings: LineString,
@@ -61,7 +55,9 @@ constructor(
 
     init {
         coordinates.forEachIndexed { index, line ->
-            require(line.size >= 2) { "LineString at index $index contains less than 2 positions." }
+            require(line.size >= 2) {
+                "LineString at index $index contains fewer than 2 positions."
+            }
         }
     }
 

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiLineString.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiLineString.kt
@@ -51,7 +51,7 @@ constructor(
      * position is represented by a [DoubleArray].
      *
      * @throws IllegalArgumentException if any of the position lists is not a valid line string or
-     * any of the arrays of doubles does not represent a valid position.
+     *   any of the arrays of doubles does not represent a valid position.
      */
     @JvmOverloads
     public constructor(

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiLineString.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiLineString.kt
@@ -14,24 +14,45 @@ import org.maplibre.spatialk.geojson.serialization.jsonProp
 import org.maplibre.spatialk.geojson.serialization.toBbox
 import org.maplibre.spatialk.geojson.serialization.toPosition
 
+/**
+ * @throws IllegalArgumentException if any of the position lists is not a valid line string
+ */
 @Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
 @Serializable(with = GeometrySerializer::class)
 public class MultiLineString
 @JvmOverloads
-constructor(public val coordinates: List<List<Position>>, override val bbox: BoundingBox? = null) :
-    Geometry() {
+constructor(
+    public val coordinates: List<List<Position>>,
+    override val bbox: BoundingBox? = null
+) : Geometry() {
+
+    /**
+     * Create a MultiLineString by a number of lists of [Position]s.
+     *
+     * @throws IllegalArgumentException if any of the position lists is not a valid line string
+     */
     @JvmOverloads
     public constructor(
         vararg coordinates: List<Position>,
         bbox: BoundingBox? = null,
     ) : this(coordinates.toList(), bbox)
 
+    /**
+     * Create a MultiLineString by a number of [LineString]s.
+     */
     @JvmOverloads
     public constructor(
         vararg lineStrings: LineString,
         bbox: BoundingBox? = null,
     ) : this(lineStrings.map { it.coordinates }, bbox)
 
+    /**
+     * Create a MultiLineString by an array (= line strings) of arrays (= positions) where each
+     * position is represented by a [DoubleArray].
+     *
+     * @throws IllegalArgumentException if any of the position lists is not a valid line string or
+     * any of the arrays of doubles does not represent a valid position.
+     */
     @JvmOverloads
     public constructor(
         coordinates: Array<Array<DoubleArray>>,
@@ -39,8 +60,8 @@ constructor(public val coordinates: List<List<Position>>, override val bbox: Bou
     ) : this(coordinates.map { it.map(::Position) }, bbox)
 
     init {
-        coordinates.forEach { line ->
-            require(line.size >= 2) { "LineString must have at least two positions" }
+        coordinates.forEachIndexed { index, line ->
+            require(line.size >= 2) { "LineString at index $index contains less than 2 positions." }
         }
     }
 

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPoint.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPoint.kt
@@ -22,12 +22,10 @@ constructor(
     /** a list of [Position]s. */
     public val coordinates: List<Position>,
     /** a bounding box */
-    override val bbox: BoundingBox? = null
+    override val bbox: BoundingBox? = null,
 ) : Geometry() {
 
-    /**
-     * Create a MultiPoint by a number of [Position]s.
-     */
+    /** Create a MultiPoint by a number of [Position]s. */
     @JvmOverloads
     public constructor(
         vararg coordinates: Position,

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPoint.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPoint.kt
@@ -18,14 +18,27 @@ import org.maplibre.spatialk.geojson.serialization.toPosition
 @Serializable(with = GeometrySerializer::class)
 public class MultiPoint
 @JvmOverloads
-constructor(public val coordinates: List<Position>, override val bbox: BoundingBox? = null) :
-    Geometry() {
+constructor(
+    /** a list of [Position]s. */
+    public val coordinates: List<Position>,
+    /** a bounding box */
+    override val bbox: BoundingBox? = null
+) : Geometry() {
+
+    /**
+     * Create a MultiPoint by a number of [Position]s.
+     */
     @JvmOverloads
     public constructor(
         vararg coordinates: Position,
         bbox: BoundingBox? = null,
     ) : this(coordinates.toList(), bbox)
 
+    /**
+     * Create a MultiPoint by an array of [DoubleArray]s that each represent a position.
+     *
+     * @throws IllegalArgumentException if any array of doubles does not represent a valid position
+     */
     @JvmOverloads
     public constructor(
         coordinates: Array<DoubleArray>,

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPolygon.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPolygon.kt
@@ -16,29 +16,64 @@ import org.maplibre.spatialk.geojson.serialization.toPosition
 
 @Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
 @Serializable(with = GeometrySerializer::class)
+/**
+ * @throws IllegalArgumentException if any of the lists does not represent a valid polygon
+ */
 public class MultiPolygon
 @JvmOverloads
 constructor(
+    /** a list (= polygons) of lists (= polygon rings) of lists of [Position]s. */
     public val coordinates: List<List<List<Position>>>,
+    /** a bounding box */
     override val bbox: BoundingBox? = null,
 ) : Geometry() {
+
+    /**
+     * Create a MultiPolygon by a number of lists (= polygon rings) of lists (= positions).
+     *
+     * @throws IllegalArgumentException if any of list does not represent a valid polygon
+     */
     @JvmOverloads
     public constructor(
         vararg coordinates: List<List<Position>>,
         bbox: BoundingBox? = null,
     ) : this(coordinates.toList(), bbox)
 
+    /**
+     * Create a MultiPolygon by a number of [Polygon]s.
+     */
     @JvmOverloads
     public constructor(
         vararg polygons: Polygon,
         bbox: BoundingBox? = null,
     ) : this(polygons.map { it.coordinates }, bbox)
 
+    /**
+     * Create a MultiPolygon by an array (= polygons) of arrays (= polygon rings) of arrays (=
+     * positions) where each position is represented by a [DoubleArray].
+     *
+     * @throws IllegalArgumentException if the array does not represent a valid multi polygon
+     */
     @JvmOverloads
     public constructor(
         coordinates: Array<Array<Array<DoubleArray>>>,
         bbox: BoundingBox? = null,
     ) : this(coordinates.map { ring -> ring.map { it.map(::Position) } }, bbox)
+
+    init {
+        coordinates.forEachIndexed { polygonIndex, polygon ->
+            polygon.forEachIndexed { ringIndex, ring ->
+                require(polygon.size >= 4) {
+                    "Line string at index $ringIndex of polygon at index $polygonIndex contains " +
+                    "less than 4 positions."
+                }
+                require(polygon.first() == polygon.last()) {
+                    "Line string at at index $ringIndex of polygon at index $polygonIndex is " +
+                    "not closed."
+                }
+            }
+        }
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPolygon.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPolygon.kt
@@ -16,9 +16,7 @@ import org.maplibre.spatialk.geojson.serialization.toPosition
 
 @Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
 @Serializable(with = GeometrySerializer::class)
-/**
- * @throws IllegalArgumentException if any of the lists does not represent a valid polygon
- */
+/** @throws IllegalArgumentException if any of the lists does not represent a valid polygon */
 public class MultiPolygon
 @JvmOverloads
 constructor(
@@ -39,9 +37,7 @@ constructor(
         bbox: BoundingBox? = null,
     ) : this(coordinates.toList(), bbox)
 
-    /**
-     * Create a MultiPolygon by a number of [Polygon]s.
-     */
+    /** Create a MultiPolygon by a number of [Polygon]s. */
     @JvmOverloads
     public constructor(
         vararg polygons: Polygon,
@@ -67,11 +63,11 @@ constructor(
             polygon.forEachIndexed { ringIndex, ring ->
                 require(polygon.size >= 4) {
                     "Line string at index $ringIndex of polygon at index $polygonIndex contains " +
-                    "less than 4 positions."
+                        "fewer than 4 positions."
                 }
                 require(polygon.first() == polygon.last()) {
                     "Line string at at index $ringIndex of polygon at index $polygonIndex is " +
-                    "not closed."
+                        "not closed."
                 }
             }
         }

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPolygon.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPolygon.kt
@@ -31,7 +31,7 @@ constructor(
     /**
      * Create a MultiPolygon by a number of lists (= polygon rings) of lists (= positions).
      *
-     * @throws IllegalArgumentException if any of list does not represent a valid polygon
+     * @throws IllegalArgumentException if any list does not represent a valid polygon
      */
     @JvmOverloads
     public constructor(
@@ -62,6 +62,8 @@ constructor(
 
     init {
         coordinates.forEachIndexed { polygonIndex, polygon ->
+            require(polygon.isNotEmpty()) { "Polygon at index $polygonIndex must not be empty." }
+
             polygon.forEachIndexed { ringIndex, ring ->
                 require(polygon.size >= 4) {
                     "Line string at index $ringIndex of polygon at index $polygonIndex contains " +

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Polygon.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Polygon.kt
@@ -16,7 +16,7 @@ import org.maplibre.spatialk.geojson.serialization.toPosition
 
 /**
  * @throws IllegalArgumentException if the coordinates are empty or any of the positions lists
- *   representing a line string is either not closed or contains less than 4 positions.
+ *   representing a line string is either not closed or contains fewer than 4 positions.
  */
 @Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
 @Serializable(with = GeometrySerializer::class)
@@ -29,14 +29,14 @@ constructor(
      */
     public val coordinates: List<List<Position>>,
     /** a bounding box */
-    override val bbox: BoundingBox? = null
+    override val bbox: BoundingBox? = null,
 ) : Geometry() {
 
     /**
      * Create a Polygon by a number of lists of [Position]s.
      *
      * @throws IllegalArgumentException if no coordinates have been specified or any of the given
-     *   position lists are either not closed or contains less than 4 positions.
+     *   position lists are either not closed or contains fewer than 4 positions.
      */
     @JvmOverloads
     public constructor(
@@ -48,7 +48,7 @@ constructor(
      * Create a Polygon by a number of closed [LineString]s.
      *
      * @throws IllegalArgumentException if no coordinates have been specified or any of the
-     *   [LineString]s is either not closed or contains less than 4 positions.
+     *   [LineString]s is either not closed or contains fewer than 4 positions.
      */
     @JvmOverloads
     public constructor(
@@ -61,8 +61,8 @@ constructor(
      * represented by a [DoubleArray].
      *
      * @throws IllegalArgumentException if the outer array is empty or any of the inner arrays does
-     *   not represent a valid closed line string or any of the arrays of doubles does not
-     *   represent a valid position.
+     *   not represent a valid closed line string or any of the arrays of doubles does not represent
+     *   a valid position.
      */
     @JvmOverloads
     public constructor(
@@ -74,12 +74,8 @@ constructor(
         require(coordinates.isNotEmpty()) { "A Polygon must not be empty." }
 
         coordinates.forEachIndexed { i, ring ->
-            require(ring.size >= 4) {
-                "Line string at index $i contains less than 4 positions."
-            }
-            require(ring.first() == ring.last()) {
-                "Line string at at index $i is not closed."
-            }
+            require(ring.size >= 4) { "Line string at index $i contains fewer than 4 positions." }
+            require(ring.first() == ring.last()) { "Line string at at index $i is not closed." }
         }
     }
 

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/LineStringTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/LineStringTest.kt
@@ -20,20 +20,18 @@ class LineStringTest {
 
     @Test
     fun throwsInvalidLineStringException() {
-        assertFailsWith(IllegalArgumentException::class) {
-            LineString(listOf(
-                Position(1.0, 1.0)
-            ))
-        }
+        assertFailsWith(IllegalArgumentException::class) { LineString(listOf(Position(1.0, 1.0))) }
     }
 
     @Test
     fun throwsInvalidPositionException() {
         assertFailsWith(IllegalArgumentException::class) {
-            LineString(arrayOf(
-                doubleArrayOf(1.0, 1.0),
-                doubleArrayOf(1.0), // !
-            ))
+            LineString(
+                arrayOf(
+                    doubleArrayOf(1.0, 1.0),
+                    doubleArrayOf(1.0), // !
+                )
+            )
         }
     }
 

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/LineStringTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/LineStringTest.kt
@@ -19,6 +19,25 @@ class LineStringTest {
     }
 
     @Test
+    fun throwsInvalidLineStringException() {
+        assertFailsWith(IllegalArgumentException::class) {
+            LineString(listOf(
+                Position(1.0, 1.0)
+            ))
+        }
+    }
+
+    @Test
+    fun throwsInvalidPositionException() {
+        assertFailsWith(IllegalArgumentException::class) {
+            LineString(arrayOf(
+                doubleArrayOf(1.0, 1.0),
+                doubleArrayOf(1.0), // !
+            ))
+        }
+    }
+
+    @Test
     fun bbox_nullWhenNotSet() {
         val points = listOf(Position(1.0, 1.0), Position(2.0, 2.0), Position(3.0, 3.0))
 

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/MultiLineStringTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/MultiLineStringTest.kt
@@ -23,19 +23,21 @@ class MultiLineStringTest {
     @Test
     fun throwsInvalidLineStringException() {
         assertFailsWith(IllegalArgumentException::class) {
-            MultiLineString(listOf(
-                Position(1.0, 1.0)
-            ))
+            MultiLineString(listOf(Position(1.0, 1.0)))
         }
     }
 
     @Test
     fun throwsInvalidPositionException() {
         assertFailsWith(IllegalArgumentException::class) {
-            MultiLineString(arrayOf(arrayOf(
-                doubleArrayOf(1.0, 1.0),
-                doubleArrayOf(1.0), // !
-            )))
+            MultiLineString(
+                arrayOf(
+                    arrayOf(
+                        doubleArrayOf(1.0, 1.0),
+                        doubleArrayOf(1.0), // !
+                    )
+                )
+            )
         }
     }
 

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/MultiLineStringTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/MultiLineStringTest.kt
@@ -21,6 +21,25 @@ class MultiLineStringTest {
     }
 
     @Test
+    fun throwsInvalidLineStringException() {
+        assertFailsWith(IllegalArgumentException::class) {
+            MultiLineString(listOf(
+                Position(1.0, 1.0)
+            ))
+        }
+    }
+
+    @Test
+    fun throwsInvalidPositionException() {
+        assertFailsWith(IllegalArgumentException::class) {
+            MultiLineString(arrayOf(arrayOf(
+                doubleArrayOf(1.0, 1.0),
+                doubleArrayOf(1.0), // !
+            )))
+        }
+    }
+
+    @Test
     fun bbox_nullWhenNotSet() {
         val points = listOf(Position(1.0, 2.0), Position(2.0, 3.0))
 

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/MultiPointTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/MultiPointTest.kt
@@ -19,6 +19,13 @@ class MultiPointTest {
     }
 
     @Test
+    fun throwsInvalidPositionException() {
+        assertFailsWith(IllegalArgumentException::class) {
+            MultiPoint(arrayOf(doubleArrayOf(1.0)))
+        }
+    }
+
+    @Test
     fun bbox_nullWhenNotSet() {
         val points = listOf(Position(1.0, 2.0), Position(2.0, 3.0))
 
@@ -56,10 +63,10 @@ class MultiPointTest {
         val bbox = BoundingBox(1.0, 2.0, 3.0, 4.0)
         val multiPoint = MultiPoint(points, bbox)
         assertNotNull(multiPoint.bbox)
-        assertEquals(1.0, multiPoint.bbox!!.west, DELTA)
-        assertEquals(2.0, multiPoint.bbox!!.south, DELTA)
-        assertEquals(3.0, multiPoint.bbox!!.east, DELTA)
-        assertEquals(4.0, multiPoint.bbox!!.north, DELTA)
+        assertEquals(1.0, multiPoint.bbox.west, DELTA)
+        assertEquals(2.0, multiPoint.bbox.south, DELTA)
+        assertEquals(3.0, multiPoint.bbox.east, DELTA)
+        assertEquals(4.0, multiPoint.bbox.north, DELTA)
     }
 
     @Test

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/MultiPointTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/MultiPointTest.kt
@@ -20,9 +20,7 @@ class MultiPointTest {
 
     @Test
     fun throwsInvalidPositionException() {
-        assertFailsWith(IllegalArgumentException::class) {
-            MultiPoint(arrayOf(doubleArrayOf(1.0)))
-        }
+        assertFailsWith(IllegalArgumentException::class) { MultiPoint(arrayOf(doubleArrayOf(1.0))) }
     }
 
     @Test

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/MultiPolygonTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/MultiPolygonTest.kt
@@ -24,12 +24,18 @@ class MultiPolygonTest {
     @Test
     fun throwsInvalidPositionException() {
         assertFailsWith(IllegalArgumentException::class) {
-            MultiPolygon(arrayOf(arrayOf(arrayOf(
-                doubleArrayOf(5.0, 2.0),
-                doubleArrayOf(1.0), // !
-                doubleArrayOf(4.0, 3.0),
-                doubleArrayOf(5.0, 2.0),
-            ))))
+            MultiPolygon(
+                arrayOf(
+                    arrayOf(
+                        arrayOf(
+                            doubleArrayOf(5.0, 2.0),
+                            doubleArrayOf(1.0), // !
+                            doubleArrayOf(4.0, 3.0),
+                            doubleArrayOf(5.0, 2.0),
+                        )
+                    )
+                )
+            )
         }
     }
 
@@ -43,23 +49,25 @@ class MultiPolygonTest {
     @Test
     fun throwsNoRingException() {
         assertFailsWith(IllegalArgumentException::class) {
-            MultiPolygon(listOf(listOf(
-                Position(10.0, 2.0),
-                Position(5.0, 2.0),
-                Position(3.0, 2.0)
-            )))
+            MultiPolygon(
+                listOf(listOf(Position(10.0, 2.0), Position(5.0, 2.0), Position(3.0, 2.0)))
+            )
         }
     }
 
     @Test
     fun throwsRingNotClosedException() {
         assertFailsWith(IllegalArgumentException::class) {
-            MultiPolygon(listOf(listOf(
-                Position(10.0, 2.0),
-                Position(5.0, 2.0),
-                Position(3.0, 2.0),
-                Position(5.0, 2.0),
-            )))
+            MultiPolygon(
+                listOf(
+                    listOf(
+                        Position(10.0, 2.0),
+                        Position(5.0, 2.0),
+                        Position(3.0, 2.0),
+                        Position(5.0, 2.0),
+                    )
+                )
+            )
         }
     }
 

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/MultiPolygonTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/MultiPolygonTest.kt
@@ -22,6 +22,41 @@ class MultiPolygonTest {
     }
 
     @Test
+    fun throwsInvalidPositionException() {
+        assertFailsWith(IllegalArgumentException::class) {
+            MultiPolygon(arrayOf(arrayOf(arrayOf(
+                doubleArrayOf(5.0, 2.0),
+                doubleArrayOf(1.0), // !
+                doubleArrayOf(4.0, 3.0),
+                doubleArrayOf(5.0, 2.0),
+            ))))
+        }
+    }
+
+    @Test
+    fun throwsNoRingException() {
+        assertFailsWith(IllegalArgumentException::class) {
+            MultiPolygon(listOf(listOf(
+                Position(10.0, 2.0),
+                Position(5.0, 2.0),
+                Position(3.0, 2.0)
+            )))
+        }
+    }
+
+    @Test
+    fun throwsRingNotClosedException() {
+        assertFailsWith(IllegalArgumentException::class) {
+            MultiPolygon(listOf(listOf(
+                Position(10.0, 2.0),
+                Position(5.0, 2.0),
+                Position(3.0, 2.0),
+                Position(5.0, 2.0),
+            )))
+        }
+    }
+
+    @Test
     fun bbox_nullWhenNotSet() {
         val points =
             listOf(Position(1.0, 2.0), Position(2.0, 3.0), Position(3.0, 4.0), Position(1.0, 2.0))
@@ -82,10 +117,10 @@ class MultiPolygonTest {
         val bbox = BoundingBox(1.0, 2.0, 3.0, 4.0)
         val multiPolygon = MultiPolygon(polygons = polygons, bbox)
         assertNotNull(multiPolygon.bbox)
-        assertEquals(1.0, multiPolygon.bbox!!.west, DELTA)
-        assertEquals(2.0, multiPolygon.bbox!!.south, DELTA)
-        assertEquals(3.0, multiPolygon.bbox!!.east, DELTA)
-        assertEquals(4.0, multiPolygon.bbox!!.north, DELTA)
+        assertEquals(1.0, multiPolygon.bbox.west, DELTA)
+        assertEquals(2.0, multiPolygon.bbox.south, DELTA)
+        assertEquals(3.0, multiPolygon.bbox.east, DELTA)
+        assertEquals(4.0, multiPolygon.bbox.north, DELTA)
     }
 
     @Test

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/MultiPolygonTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/MultiPolygonTest.kt
@@ -34,6 +34,13 @@ class MultiPolygonTest {
     }
 
     @Test
+    fun throwsEmptyPolygonException() {
+        assertFailsWith(IllegalArgumentException::class) {
+            MultiPolygon(listOf(listOf<List<Position>>()))
+        }
+    }
+
+    @Test
     fun throwsNoRingException() {
         assertFailsWith(IllegalArgumentException::class) {
             MultiPolygon(listOf(listOf(

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/PolygonTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/PolygonTest.kt
@@ -17,32 +17,47 @@ class PolygonTest {
         assertNotNull(polygon)
     }
 
-    //    @Test
-    //    fun fromOuterInner_throwsNotLinearRingException() {
-    //        val points = arrayOf(
-    //            Point(10.0, 2.0),
-    //            Point(5.0, 2.0),
-    //            Point(3.0, 2.0)
-    //        )
-    //
-    //        assertFailsWith(IllegalArgumentException::class) {
-    //            Polygon(LineString(points = points))
-    //        }
-    //    }
+    @Test
+    fun throwsEmptyException() {
+        assertFailsWith(IllegalArgumentException::class) {
+            Polygon(listOf<List<Position>>())
+        }
+    }
 
-    //    @Test
-    //    fun fromOuterInner_throwsNotConnectedLinearRingException() {
-    //        val points = arrayOf(
-    //            Point(10.0, 2.0),
-    //            Point(5.0, 2.0),
-    //            Point(3.0, 2.0),
-    //            Point(5.0, 2.0),
-    //        )
-    //
-    //        assertFailsWith(IllegalArgumentException::class) {
-    //            Polygon(LineString(* points))
-    //        }
-    //    }
+    @Test
+    fun throwsInvalidPositionException() {
+        assertFailsWith(IllegalArgumentException::class) {
+            Polygon(arrayOf(arrayOf(
+                doubleArrayOf(5.0, 2.0),
+                doubleArrayOf(1.0), // !
+                doubleArrayOf(4.0, 3.0),
+                doubleArrayOf(5.0, 2.0),
+            )))
+        }
+    }
+
+    @Test
+    fun throwsNoRingException() {
+        assertFailsWith(IllegalArgumentException::class) {
+            Polygon(listOf(
+                Position(10.0, 2.0),
+                Position(5.0, 2.0),
+                Position(3.0, 2.0)
+            ))
+        }
+    }
+
+    @Test
+    fun throwsRingNotClosedException() {
+        assertFailsWith(IllegalArgumentException::class) {
+            Polygon(listOf(
+                Position(10.0, 2.0),
+                Position(5.0, 2.0),
+                Position(3.0, 2.0),
+                Position(5.0, 2.0),
+            ))
+        }
+    }
 
     @Test
     fun fromOuterInner_handlesSingleLineStringCorrectly() {

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/PolygonTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/PolygonTest.kt
@@ -19,43 +19,43 @@ class PolygonTest {
 
     @Test
     fun throwsEmptyException() {
-        assertFailsWith(IllegalArgumentException::class) {
-            Polygon(listOf<List<Position>>())
-        }
+        assertFailsWith(IllegalArgumentException::class) { Polygon(listOf<List<Position>>()) }
     }
 
     @Test
     fun throwsInvalidPositionException() {
         assertFailsWith(IllegalArgumentException::class) {
-            Polygon(arrayOf(arrayOf(
-                doubleArrayOf(5.0, 2.0),
-                doubleArrayOf(1.0), // !
-                doubleArrayOf(4.0, 3.0),
-                doubleArrayOf(5.0, 2.0),
-            )))
+            Polygon(
+                arrayOf(
+                    arrayOf(
+                        doubleArrayOf(5.0, 2.0),
+                        doubleArrayOf(1.0), // !
+                        doubleArrayOf(4.0, 3.0),
+                        doubleArrayOf(5.0, 2.0),
+                    )
+                )
+            )
         }
     }
 
     @Test
     fun throwsNoRingException() {
         assertFailsWith(IllegalArgumentException::class) {
-            Polygon(listOf(
-                Position(10.0, 2.0),
-                Position(5.0, 2.0),
-                Position(3.0, 2.0)
-            ))
+            Polygon(listOf(Position(10.0, 2.0), Position(5.0, 2.0), Position(3.0, 2.0)))
         }
     }
 
     @Test
     fun throwsRingNotClosedException() {
         assertFailsWith(IllegalArgumentException::class) {
-            Polygon(listOf(
-                Position(10.0, 2.0),
-                Position(5.0, 2.0),
-                Position(3.0, 2.0),
-                Position(5.0, 2.0),
-            ))
+            Polygon(
+                listOf(
+                    Position(10.0, 2.0),
+                    Position(5.0, 2.0),
+                    Position(3.0, 2.0),
+                    Position(5.0, 2.0),
+                )
+            )
         }
     }
 


### PR DESCRIPTION
Implement point 3 from #154.

I didn't actually take the code from maplibre-java#40 because the constructors are different and after all, I didn't find anything in the GeoJson spec that would disallow an empty `MultiPolygon`, `MultiLineString` or `MultiPoint` (but that PR requires it.)

**NOTE:** Currently we check on construction if the data passed is valid. However, `List`s are just an interface. E.g. the data behind it may change later, then we can end up with an invalid GeoJson after all. To plug this, we'd **always** have to deep copy the data passed. Should we do that to guarantee consistency? It will have *some* performance hit.

Also, note that I had to basically duplicate the checks made in Polygon also for MultiPolygon, same for LineString. This is because the base data structure for `MultiPolygon` is **not** `List<Polygon>` but `List<List<List<Position>>>`. Not sure if there is a good reason for this, but changing it would probably break backward compatibility.

I think it _used to be_ like that too in maplibre-java#40, but I think we went with `List<Polygon>` in the end, because that's how library users usually would want to access this data and if `List<Polygon>` was just a getter
```kotlin
val polygons: List<Polygon> get() =
  coordinates.map { Polygon(it) }
```
then every _access_ to any of these data structures will create some lists, and that's not so nice.