### PR TITLE
clean up IDE squigglies, unnecessary annotations, and inconsistent @JvmName

### DIFF
--- a/geojson/src/commonBench/kotlin/org/maplibre/spatialk/geojson/GeoJsonBenchmark.kt
+++ b/geojson/src/commonBench/kotlin/org/maplibre/spatialk/geojson/GeoJsonBenchmark.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MagicNumber")
-
 package org.maplibre.spatialk.geojson
 
 import kotlin.random.Random

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/BoundingBox.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/BoundingBox.kt
@@ -2,7 +2,6 @@ package org.maplibre.spatialk.geojson
 
 import kotlin.jvm.JvmStatic
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import org.maplibre.spatialk.geojson.serialization.BoundingBoxSerializer
 import org.maplibre.spatialk.geojson.serialization.GeoJson
 
@@ -14,7 +13,7 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  *
  * When serialized, a BoundingBox is represented as an array of length 2*n where n is the number of
  * dimensions represented in the contained geometries, with all axes of the most southwesterly point
- * followed by all axes of the northeasterly point. The axes order of a BoundingBox follow the axes
+ * followed by all axes of the northeasterly point. The axes order of a BoundingBox follows the axes
  * order of geometries.
  *
  * For the BoundingBox to be serialized in 3D form, both Positions must have a defined altitude.
@@ -26,7 +25,6 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  *   https://tools.ietf.org/html/rfc7946#section-5</a>
  */
 @Serializable(with = BoundingBoxSerializer::class)
-@Suppress("MagicNumber")
 public class BoundingBox(public val coordinates: DoubleArray) {
     init {
         require(coordinates.size == 4 || coordinates.size == 6) {
@@ -104,9 +102,7 @@ public class BoundingBox(public val coordinates: DoubleArray) {
 
         other as BoundingBox
 
-        if (!coordinates.contentEquals(other.coordinates)) return false
-
-        return true
+        return coordinates.contentEquals(other.coordinates)
     }
 
     override fun hashCode(): Int {
@@ -134,6 +130,5 @@ public class BoundingBox(public val coordinates: DoubleArray) {
     }
 }
 
-@Suppress("MagicNumber")
 public val BoundingBox.hasAltitude: Boolean
     get() = coordinates.size == 6

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Feature.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Feature.kt
@@ -5,7 +5,6 @@ import kotlin.jvm.JvmStatic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.double
@@ -24,9 +23,7 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  *   https://tools.ietf.org/html/rfc7946#section-3.2</a>
  * @see FeatureCollection
  */
-@Suppress("TooManyFunctions")
 @Serializable(with = FeatureSerializer::class)
-@JsonIgnoreUnknownKeys
 @SerialName("Feature")
 public class Feature(
     public val geometry: Geometry?,

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/FeatureCollection.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/FeatureCollection.kt
@@ -9,7 +9,7 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
 /**
  * A FeatureCollection object is a collection of [Feature] objects. This class implements the
  * [Collection] interface and can be used as a Collection directly. The list of features contained
- * in this collection are also accessible through the [features] property.
+ * in this collection is also accessible through the [features] property.
  *
  * @property features The collection of [Feature] objects stored in this collection
  * @see <a href="https://tools.ietf.org/html/rfc7946#section-3.3">

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/GeometryCollection.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/GeometryCollection.kt
@@ -4,7 +4,6 @@ import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import org.maplibre.spatialk.geojson.serialization.GeoJson
 
 /**
@@ -14,8 +13,6 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("GeometryCollection")
-@JsonIgnoreUnknownKeys
-@Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
 public class GeometryCollection
 @JvmOverloads
 constructor(public val geometries: List<Geometry>, override val bbox: BoundingBox? = null) :

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/LineString.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/LineString.kt
@@ -4,7 +4,6 @@ import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import org.maplibre.spatialk.geojson.serialization.GeoJson
 
 /**
@@ -15,8 +14,6 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("LineString")
-@JsonIgnoreUnknownKeys
-@Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
 public class LineString
 @JvmOverloads
 constructor(
@@ -51,8 +48,8 @@ constructor(
     /**
      * Create a LineString by an array of [DoubleArray]s that each represent a position.
      *
-     * @throws IllegalArgumentException if the coordinates contain fewer than two positions or any
-     *   array of doubles does not represent a valid position
+     * @throws IllegalArgumentException if the coordinates contain fewer than two positions, or if
+     *   any array of doubles does not represent a valid position
      */
     @JvmOverloads
     public constructor(

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiLineString.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiLineString.kt
@@ -4,7 +4,6 @@ import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import org.maplibre.spatialk.geojson.serialization.GeoJson
 
 /**
@@ -15,8 +14,6 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("MultiLineString")
-@JsonIgnoreUnknownKeys
-@Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
 public class MultiLineString
 @JvmOverloads
 constructor(public val coordinates: List<List<Position>>, override val bbox: BoundingBox? = null) :

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Polygon.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Polygon.kt
@@ -17,7 +17,7 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  * - A linear ring MUST follow the right-hand rule with respect to the area it bounds, i.e.,
  *   exterior rings are counterclockwise, and holes are clockwise.
  *
- * @throws IllegalArgumentException if the coordinates are empty or any of the positions lists
+ * @throws IllegalArgumentException if the coordinates are empty or any of the position lists
  *   representing a line string is either not closed or contains fewer than 4 positions.
  * @see <a href="https://tools.ietf.org/html/rfc7946#section-3.1.6">
  *   https://tools.ietf.org/html/rfc7946#section-3.1.6</a>
@@ -30,7 +30,7 @@ public class Polygon
 @JvmOverloads
 constructor(
     /**
-     * a list (= polygon rings) of lists of [Position]s that represent this polygon. The first ring
+     * A list (= polygon rings) of lists of [Position]s that represent this polygon. The first ring
      * represents the exterior ring while any others are interior rings (= holes).
      */
     public val coordinates: List<List<Position>>,
@@ -59,9 +59,9 @@ constructor(
      * Create a Polygon by arrays (= polygon rings) of arrays (= positions) where each position is
      * represented by a [DoubleArray].
      *
-     * @throws IllegalArgumentException if the outer array is empty or any of the inner arrays does
-     *   not represent a valid closed line string or any of the arrays of doubles does not represent
-     *   a valid position.
+     * @throws IllegalArgumentException if the outer array is empty, or if any of the inner arrays
+     *   does not represent a valid closed line string, or if any of the arrays of doubles does not
+     *   represent a valid position.
      */
     @JvmOverloads
     public constructor(

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Position.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Position.kt
@@ -19,7 +19,7 @@ import org.maplibre.spatialk.geojson.serialization.PositionSerializer
  * LngLat(longitude = -75.0, latitude = 45.0)
  * ```
  *
- * will be serialized as
+ * Will be serialized as
  *
  * ```json
  * [-75.0,45.0]
@@ -100,9 +100,7 @@ public class Position(public val coordinates: DoubleArray) {
 
         other as Position
 
-        if (!coordinates.contentEquals(other.coordinates)) return false
-
-        return true
+        return coordinates.contentEquals(other.coordinates)
     }
 
     override fun hashCode(): Int {

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/dsl/FeatureCollectionDsl.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/dsl/FeatureCollectionDsl.kt
@@ -1,8 +1,8 @@
-@file:JvmName("-FeatureCollectionDslKt")
+@file:JvmSynthetic
 
 package org.maplibre.spatialk.geojson.dsl
 
-import kotlin.jvm.JvmName
+import kotlin.jvm.JvmSynthetic
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.FeatureCollection

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/dsl/FeatureDsl.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/dsl/FeatureDsl.kt
@@ -1,9 +1,8 @@
-@file:JvmName("-FeatureDslKt")
-@file:Suppress("MatchingDeclarationName")
+@file:JvmSynthetic
 
 package org.maplibre.spatialk.geojson.dsl
 
-import kotlin.jvm.JvmName
+import kotlin.jvm.JvmSynthetic
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import org.maplibre.spatialk.geojson.BoundingBox

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/dsl/GeoJsonDsl.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/dsl/GeoJsonDsl.kt
@@ -1,7 +1,7 @@
-@file:JvmName("-GeoJsonDslKt")
+@file:JvmSynthetic
 
 package org.maplibre.spatialk.geojson.dsl
 
-import kotlin.jvm.JvmName
+import kotlin.jvm.JvmSynthetic
 
 @DslMarker internal annotation class GeoJsonDsl

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/dsl/GeometryDsl.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/dsl/GeometryDsl.kt
@@ -1,8 +1,8 @@
-@file:JvmName("-GeometryDslKt")
+@file:JvmSynthetic
 
 package org.maplibre.spatialk.geojson.dsl
 
-import kotlin.jvm.JvmName
+import kotlin.jvm.JvmSynthetic
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Geometry
 import org.maplibre.spatialk.geojson.GeometryCollection

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/dsl/Position.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/dsl/Position.kt
@@ -1,10 +1,13 @@
+@file:JvmSynthetic
+
 package org.maplibre.spatialk.geojson.dsl
 
+import kotlin.jvm.JvmSynthetic
 import org.maplibre.spatialk.geojson.Position
 
-@Suppress("MagicNumber") private val LONGITUDE_RANGE = -180.0..180.0
+private val LONGITUDE_RANGE = -180.0..180.0
 
-@Suppress("MagicNumber") private val LATITUDE_RANGE = -90.0..90.0
+private val LATITUDE_RANGE = -90.0..90.0
 
 @GeoJsonDsl
 public fun lngLat(longitude: Double, latitude: Double): Position {

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/serialization/FeatureSerializer.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/serialization/FeatureSerializer.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.Geometry
@@ -37,7 +36,6 @@ public object FeatureSerializer : KSerializer<Feature> {
 }
 
 @Serializable
-@JsonIgnoreUnknownKeys
 private data class FeatureSurrogate(
     val bbox: List<Double>? = null,
     val geometry: Geometry?,

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/BoundingBoxTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/BoundingBoxTest.kt
@@ -32,7 +32,7 @@ class BoundingBoxTest {
     }
 
     @Test
-    fun JSON_serializing_without_altitude() {
+    fun json_serializing_without_altitude() {
         val boundingBox = BoundingBox(Position(1.1, 2.2), Position(3.3, 4.4))
         val json = boundingBox.json()
 
@@ -40,7 +40,7 @@ class BoundingBoxTest {
     }
 
     @Test
-    fun JSON_serializing_with_altitude() {
+    fun json_serializing_with_altitude() {
         val boundingBox = BoundingBox(Position(1.1, 2.2, 3.3), Position(4.4, 5.5, 6.6))
         val json = boundingBox.json()
 
@@ -51,7 +51,7 @@ class BoundingBoxTest {
     }
 
     @Test
-    fun JSON_deserializing_without_altitude() {
+    fun json_deserializing_without_altitude() {
         val json = "[1.0, 2.0, 3.0, 4.0]"
         val boundingBox = BoundingBox.fromJson(json)
 
@@ -59,7 +59,7 @@ class BoundingBoxTest {
     }
 
     @Test
-    fun JSON_deserializing_with_altitude() {
+    fun json_deserializing_with_altitude() {
         val json = "[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]"
         val boundingBox = BoundingBox.fromJson(json)
 
@@ -67,7 +67,7 @@ class BoundingBoxTest {
     }
 
     @Test
-    fun JSON_deserializing_with_wrong_array_size() {
+    fun json_deserializing_with_wrong_array_size() {
         val json = "[1.0, 2.0, 3.0, 4.0, 5.0]"
 
         assertFailsWith(IllegalArgumentException::class) { BoundingBox.fromJson(json) }

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/BoundingBoxTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/BoundingBoxTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlinx.serialization.json.Json
+import org.maplibre.spatialk.geojson.serialization.GeoJson
 
 class BoundingBoxTest {
     @Test
@@ -45,8 +46,8 @@ class BoundingBoxTest {
         val json = boundingBox.json()
 
         assertEquals(
-            Json.parseToJsonElement(json),
-            Json.parseToJsonElement("[1.1, 2.2, 3.3, 4.4, 5.5, 6.6]"),
+            GeoJson.parseToJsonElement(json),
+            GeoJson.parseToJsonElement("[1.1, 2.2, 3.3, 4.4, 5.5, 6.6]"),
         )
     }
 

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/SerializationTests.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/SerializationTests.kt
@@ -6,7 +6,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.Json
 import org.maplibre.spatialk.geojson.serialization.GeoJson
 
 @Suppress("MagicNumber", "TooManyFunctions")
@@ -38,7 +37,7 @@ class SerializationTests {
         assertEquals(Position(60.2, 23.2354, 100.5), altitude)
 
         val list =
-            Json.decodeFromString(
+            GeoJson.decodeFromString(
                 ListSerializer(Position.serializer()),
                 "[[12.3,45.6],[78.9,12.3]]",
             )
@@ -70,11 +69,11 @@ class SerializationTests {
         assertEquals(BoundingBox(Position(-10.5, -10.5), Position(10.5, 10.5)), bbox)
 
         val bbox3D =
-            Json.decodeFromString(BoundingBox.serializer(), "[-10.5,-10.5,-100.8,10.5,10.5,5.5]")
+            GeoJson.decodeFromString(BoundingBox.serializer(), "[-10.5,-10.5,-100.8,10.5,10.5,5.5]")
         assertEquals(BoundingBox(Position(-10.5, -10.5, -100.8), Position(10.5, 10.5, 5.5)), bbox3D)
 
         assertFailsWith<SerializationException> {
-            Json.decodeFromString(BoundingBox.serializer(), "[12.3]")
+            GeoJson.decodeFromString(BoundingBox.serializer(), "[12.3]")
         }
     }
 

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/utils/Json.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/utils/Json.kt
@@ -1,11 +1,10 @@
 package org.maplibre.spatialk.geojson.utils
 
 import kotlin.test.assertEquals
-import kotlinx.serialization.json.Json
+import org.maplibre.spatialk.geojson.serialization.GeoJson
 
 const val DELTA: Double = 1E-10
 
 fun compareJson(expectedJson: String, actualJson: String) {
-    val json = Json { isLenient = true }
-    assertEquals(json.parseToJsonElement(expectedJson), json.parseToJsonElement(actualJson))
+    assertEquals(GeoJson.parseToJsonElement(expectedJson), GeoJson.parseToJsonElement(actualJson))
 }

--- a/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Booleans.kt
+++ b/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Booleans.kt
@@ -1,5 +1,4 @@
 @file:OptIn(ExperimentalTurfApi::class)
-@file:Suppress("LongMethod", "MagicNumber", "NestedBlockDepth")
 
 package org.maplibre.spatialk.turf
 
@@ -16,8 +15,8 @@ import org.maplibre.spatialk.geojson.Position
  *
  * @param point input point
  * @param polygon input polygon
- * @param ignoreBoundary True if polygon boundary should be ignored when determining if the point is
- *   inside the polygon otherwise false.
+ * @param ignoreBoundary True if the polygon boundary should be ignored when determining if the
+ *   point is inside the polygon otherwise false.
  * @return `true` if the Position is inside the Polygon; `false` if the Position is not inside the
  *   Polygon
  */
@@ -39,8 +38,8 @@ public fun booleanPointInPolygon(
  *
  * @param point input point
  * @param polygon input multipolygon
- * @param ignoreBoundary True if polygon boundary should be ignored when determining if the point is
- *   inside the polygon otherwise false.
+ * @param ignoreBoundary True if the polygon boundary should be ignored when determining if the
+ *   point is inside the polygon otherwise false.
  * @return `true` if the Position is inside the Polygon; `false` if the Position is not inside the
  *   Polygon
  */
@@ -55,14 +54,13 @@ public fun booleanPointInPolygon(
     return booleanPointInPolygon(point.coordinates, bbox, polys, ignoreBoundary)
 }
 
-@Suppress("ReturnCount")
 private fun booleanPointInPolygon(
     point: Position,
     bbox: BoundingBox,
     polys: List<List<List<Position>>>,
     ignoreBoundary: Boolean,
 ): Boolean {
-    // Quick elimination if point is not inside bbox
+    // Quick elimination if the point is not inside the bbox
     if (!inBBox(point, bbox)) {
         return false
     }
@@ -89,23 +87,20 @@ private fun booleanPointInPolygon(
 private fun inRing(point: Position, ring: List<Position>, ignoreBoundary: Boolean): Boolean {
     val pt = point.coordinates
     var isInside = false
-    @Suppress("NAME_SHADOWING")
-    val ring =
+    val openRing =
         if (
             ring[0].coordinates[0] == ring.last().coordinates[0] &&
                 ring[0].coordinates[1] == ring.last().coordinates[1]
         ) {
             ring.slice(0 until ring.size - 1)
-        } else {
-            ring
-        }
+        } else ring
     var i = 0
-    var j = ring.size - 1
-    while (i < ring.size) {
-        val xi = ring[i].coordinates[0]
-        val yi = ring[i].coordinates[1]
-        val xj = ring[j].coordinates[0]
-        val yj = ring[j].coordinates[1]
+    var j = openRing.size - 1
+    while (i < openRing.size) {
+        val xi = openRing[i].coordinates[0]
+        val yi = openRing[i].coordinates[1]
+        val xj = openRing[j].coordinates[0]
+        val yj = openRing[j].coordinates[1]
         val onBoundary =
             pt[1] * (xi - xj) + yi * (xj - pt[0]) + yj * (pt[0] - xi) == 0.0 &&
                 (xi - pt[0]) * (xj - pt[0]) <= 0 &&

--- a/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Booleans.kt
+++ b/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Booleans.kt
@@ -1,7 +1,9 @@
+@file:JvmName("TurfBooleans")
 @file:OptIn(ExperimentalTurfApi::class)
 
 package org.maplibre.spatialk.turf
 
+import kotlin.jvm.JvmName
 import kotlin.jvm.JvmOverloads
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.MultiPolygon

--- a/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Grids.kt
+++ b/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Grids.kt
@@ -1,5 +1,8 @@
+@file:JvmName("TurfGrids")
+
 package org.maplibre.spatialk.turf
 
+import kotlin.jvm.JvmName
 import kotlin.math.abs
 import kotlin.math.floor
 import org.maplibre.spatialk.geojson.BoundingBox

--- a/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/MathUtils.kt
+++ b/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/MathUtils.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MagicNumber")
-
 package org.maplibre.spatialk.turf
 
 import kotlin.math.PI

--- a/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Measurement.kt
+++ b/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Measurement.kt
@@ -1,5 +1,4 @@
 @file:JvmName("TurfMeasurement")
-@file:Suppress("TooManyFunctions")
 
 package org.maplibre.spatialk.turf
 
@@ -39,7 +38,6 @@ import org.maplibre.spatialk.geojson.Position
  * @return A position [distance] [units] along the line
  */
 @JvmOverloads
-@Suppress("MagicNumber")
 @ExperimentalTurfApi
 public fun along(line: LineString, distance: Double, units: Units = Units.Kilometers): Position {
     var travelled = 0.0
@@ -102,7 +100,7 @@ public const val AREA_EARTH_RADIUS: Int = 6378137
 
 /**
  * Calculates the approximate area of the [polygon][coordinates] were it projected onto the earth.
- * Note that this area will be positive if ring is oriented clockwise, otherwise it will be
+ * Note that this area will be positive if the ring is oriented clockwise, otherwise it will be
  * negative.
  *
  * Reference: Robert. G. Chamberlain and William H. Duquette, "Some Algorithms for Polygons on a
@@ -150,7 +148,7 @@ private fun ringArea(coordinates: List<Position>): Double {
 }
 
 /**
- * Takes a geometry and calculates the bbox of all input features, and returns a bounding box.
+ * Takes a geometry and calculates the bounding box of all input features.
  *
  * @param geometry The geometry to compute a bounding box for.
  * @return A [BoundingBox] that covers the geometry.
@@ -159,7 +157,7 @@ private fun ringArea(coordinates: List<Position>): Double {
 public fun bbox(geometry: Geometry): BoundingBox = computeBbox(geometry.coordAll())
 
 /**
- * Takes a geometry and calculates the bbox of all input features, and returns a bounding box.
+ * Takes a geometry and calculates the bounding box of all input features.
  *
  * @param geometry The geometry to compute a bounding box for.
  * @return A [BoundingBox] that covers the geometry.
@@ -168,7 +166,7 @@ public fun bbox(geometry: Geometry): BoundingBox = computeBbox(geometry.coordAll
 public fun bbox(geometry: Point): BoundingBox = computeBbox(geometry.coordAll())
 
 /**
- * Takes a geometry and calculates the bbox of all input features, and returns a bounding box.
+ * Takes a geometry and calculates the bounding box of all input features.
  *
  * @param geometry The geometry to compute a bounding box for.
  * @return A [BoundingBox] that covers the geometry.
@@ -177,7 +175,7 @@ public fun bbox(geometry: Point): BoundingBox = computeBbox(geometry.coordAll())
 public fun bbox(geometry: MultiPoint): BoundingBox = computeBbox(geometry.coordAll())
 
 /**
- * Takes a geometry and calculates the bbox of all input features, and returns a bounding box.
+ * Takes a geometry and calculates the bounding box of all input features.
  *
  * @param geometry The geometry to compute a bounding box for.
  * @return A [BoundingBox] that covers the geometry.
@@ -186,7 +184,7 @@ public fun bbox(geometry: MultiPoint): BoundingBox = computeBbox(geometry.coordA
 public fun bbox(geometry: LineString): BoundingBox = computeBbox(geometry.coordAll())
 
 /**
- * Takes a geometry and calculates the bbox of all input features, and returns a bounding box.
+ * Takes a geometry and calculates the bounding box of all input features.
  *
  * @param geometry The geometry to compute a bounding box for.
  * @return A [BoundingBox] that covers the geometry.
@@ -195,7 +193,7 @@ public fun bbox(geometry: LineString): BoundingBox = computeBbox(geometry.coordA
 public fun bbox(geometry: MultiLineString): BoundingBox = computeBbox(geometry.coordAll())
 
 /**
- * Takes a geometry and calculates the bbox of all input features, and returns a bounding box.
+ * Takes a geometry and calculates the bounding box of all input features.
  *
  * @param geometry The geometry to compute a bounding box for.
  * @return A [BoundingBox] that covers the geometry.
@@ -204,7 +202,7 @@ public fun bbox(geometry: MultiLineString): BoundingBox = computeBbox(geometry.c
 public fun bbox(geometry: Polygon): BoundingBox = computeBbox(geometry.coordAll())
 
 /**
- * Takes a geometry and calculates the bbox of all input features, and returns a bounding box.
+ * Takes a geometry and calculates the bounding box of all input features.
  *
  * @param geometry The geometry to compute a bounding box for.
  * @return A [BoundingBox] that covers the geometry.
@@ -213,7 +211,7 @@ public fun bbox(geometry: Polygon): BoundingBox = computeBbox(geometry.coordAll(
 public fun bbox(geometry: MultiPolygon): BoundingBox = computeBbox(geometry.coordAll())
 
 /**
- * Takes a feature and calculates the bbox of the feature's geometry, and returns a bounding box.
+ * Takes a feature and calculates the bounding box of the feature's geometry.
  *
  * @param feature The feature to compute a bounding box for.
  * @return A [BoundingBox] that covers the geometry.
@@ -222,7 +220,8 @@ public fun bbox(geometry: MultiPolygon): BoundingBox = computeBbox(geometry.coor
 public fun bbox(feature: Feature): BoundingBox = computeBbox(feature.coordAll() ?: emptyList())
 
 /**
- * Takes a feature collection and calculates a bbox that covers all features in the collection.
+ * Takes a feature collection and calculates a bounding box that covers all features in the
+ * collection.
  *
  * @param featureCollection The collection of features to compute a bounding box for.
  * @return A [BoundingBox] that covers the geometry.
@@ -231,7 +230,6 @@ public fun bbox(feature: Feature): BoundingBox = computeBbox(feature.coordAll() 
 public fun bbox(featureCollection: FeatureCollection): BoundingBox =
     computeBbox(featureCollection.coordAll())
 
-@Suppress("MagicNumber")
 public fun computeBbox(coordinates: List<Position>): BoundingBox {
     val result =
         doubleArrayOf(
@@ -259,7 +257,7 @@ public fun computeBbox(coordinates: List<Position>): BoundingBox {
 }
 
 /**
- * Takes a bbox and returns an equivalent [Polygon].
+ * Takes a bounding box and returns an equivalent [Polygon].
  *
  * @param bbox The bounding box to convert to a Polygon.
  * @return The bounding box as a polygon
@@ -285,7 +283,7 @@ public fun bboxPolygon(bbox: BoundingBox): Polygon {
 @JvmSynthetic @ExperimentalTurfApi public fun BoundingBox.toPolygon(): Polygon = bboxPolygon(this)
 
 /**
- * Takes two positions ([start], [end]) and finds the geographic bearing between them, i.e. the
+ * Takes two positions ([start], [end]) and finds the geographic bearing between them, i.e., the
  * angle measured in degrees from the north line (0 degrees)
  *
  * @param start starting point
@@ -309,7 +307,6 @@ public fun bearing(start: Position, end: Position, final: Boolean = false): Doub
     return degrees(atan2(a, b))
 }
 
-@Suppress("MagicNumber")
 @ExperimentalTurfApi
 internal fun finalBearing(start: Position, end: Position): Double =
     (bearing(end, start) + 180) % 360
@@ -465,7 +462,7 @@ public fun center(feature: Feature): Point {
 }
 
 /**
- * It overloads the center(feature: Feature) method.
+ * It overloads the `center(feature: Feature)` method.
  *
  * @param geometry the [Geometry] to find the center for
  */
@@ -483,9 +480,8 @@ public fun center(geometry: Geometry): Point {
  * @param pointCount number of positions on the arc (including [start] and [end])
  * @param antimeridianOffset from antimeridian in degrees (default long. = +/- 10deg, geometries
  *   within 170deg to -170deg will be split)
+ * @throws IllegalArgumentException if [start] and [end] are diametrically opposite.
  */
-@Suppress("CyclomaticComplexMethod")
-@Throws(IllegalArgumentException::class)
 @ExperimentalTurfApi
 public fun greatCircle(
     start: Position,
@@ -498,7 +494,6 @@ public fun greatCircle(
     val deltaLatitude = start.latitude - end.latitude
 
     // check antipodal positions
-    @Suppress("MagicNumber")
     require(abs(deltaLatitude) != 0.0 && abs(deltaLongitude % 360) - ANTIMERIDIAN_POS != 0.0) {
         "Input $start and $end are diametrically opposite, thus there is no single route but rather infinite"
     }
@@ -550,8 +545,7 @@ public fun greatCircle(
             plainArc
                 .zipWithNext { a, b -> abs(a.longitude - b.longitude) }
                 .filter { it <= diffSpace } // Filter differences less than or equal to diffSpace
-                .maxByOrNull { it }
-                ?.toDouble() ?: 0.0
+                .maxByOrNull { it } ?: 0.0
 
         val poMulti = mutableListOf<List<Position>>()
         if (passesAntimeridian && maxSmallDiffLong < antimeridianOffset) {

--- a/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Meta.kt
+++ b/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Meta.kt
@@ -42,18 +42,16 @@ public fun Polygon.coordAll(): List<Position> = coordinates.reduce { acc, list -
 
 @ExperimentalTurfApi
 public fun MultiPolygon.coordAll(): List<Position> =
-    coordinates.fold(emptyList<Position>()) { acc, list ->
+    coordinates.fold(emptyList()) { acc, list ->
         list.reduce { innerAcc, innerList -> innerAcc + innerList } + acc
     }
 
 @ExperimentalTurfApi
 public fun GeometryCollection.coordAll(): List<Position> =
-    geometries.fold(emptyList<Position>()) { acc, geometry -> acc + geometry.coordAll() }
+    geometries.fold(emptyList()) { acc, geometry -> acc + geometry.coordAll() }
 
 @ExperimentalTurfApi public fun Feature.coordAll(): List<Position>? = geometry?.coordAll()
 
 @ExperimentalTurfApi
 public fun FeatureCollection.coordAll(): List<Position> =
-    features.fold(emptyList<Position>()) { acc, feature ->
-        acc + (feature.coordAll() ?: emptyList())
-    }
+    features.fold(emptyList()) { acc, feature -> acc + (feature.coordAll() ?: emptyList()) }

--- a/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Miscellaneous.kt
+++ b/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Miscellaneous.kt
@@ -33,7 +33,6 @@ public fun lineIntersect(line1: LineString, line2: LineString): List<Position> {
  * @param line2 A [LineString] (must contain exactly 2 coordinates)
  * @return The position of the intersection, or null if the two lines do not intersect.
  */
-@Suppress("ReturnCount")
 @ExperimentalTurfApi
 internal fun intersects(line1: LineString, line2: LineString): Position? {
     require(line1.coordinates.size == 2) { "line1 must contain exactly 2 coordinates" }
@@ -74,7 +73,7 @@ internal fun intersects(line1: LineString, line2: LineString): Position? {
  *
  * @param start Start position
  * @param stop Stop position
- * @param line The line string to slice
+ * @param line The [LineString] to slice
  * @return The sliced subsection of the line
  */
 @ExperimentalTurfApi
@@ -143,7 +142,6 @@ public fun nearestPointOnLine(
     return nearestPointOnLine(lines.coordinates, point, units)
 }
 
-@Suppress("MagicNumber")
 @ExperimentalTurfApi
 internal fun nearestPointOnLine(
     lines: List<List<Position>>,

--- a/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Miscellaneous.kt
+++ b/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Miscellaneous.kt
@@ -1,4 +1,4 @@
-@file:JvmName("TurfMisc")
+@file:JvmName("TurfMiscellaneous")
 
 package org.maplibre.spatialk.turf
 

--- a/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Transformation.kt
+++ b/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Transformation.kt
@@ -1,5 +1,8 @@
+@file:JvmName("TurfTransformation")
+
 package org.maplibre.spatialk.turf
 
+import kotlin.jvm.JvmName
 import kotlin.math.pow
 import org.maplibre.spatialk.geojson.LineString
 import org.maplibre.spatialk.geojson.Point

--- a/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Transformation.kt
+++ b/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Transformation.kt
@@ -35,7 +35,6 @@ public fun bezierSpline(
  * @param sharpness a measure of how curvy the path should be between splines
  * @return A [List] containing [Position] of a curved line around the positions of the input line
  */
-@Suppress("MagicNumber")
 public fun bezierSpline(
     coords: List<Position>,
     duration: Int = 10_000,
@@ -147,7 +146,7 @@ public fun bezierSpline(
  *
  * @param center center point of circle
  * @param radius radius of the circle defined in [units]
- * @param steps number of steps, must be at least four. Default is 64
+ * @param steps the number of steps must be at least four. Default is 64
  * @param units unit of [radius], default is [Units.Kilometers]
  */
 @ExperimentalTurfApi

--- a/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Units.kt
+++ b/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Units.kt
@@ -17,7 +17,6 @@ internal const val ANTIMERIDIAN_NEG = -180.0
  * @property areaFactor Area of measurement factors based on 1 square meter.
  */
 @ExperimentalTurfApi
-@Suppress("MagicNumber")
 public enum class Units(
     internal val unitFactor: Double,
     internal val factor: Double,

--- a/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Utils.kt
+++ b/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Utils.kt
@@ -77,9 +77,8 @@ public fun convertLength(
  * @param from Original units of the [area]
  * @param to Units to convert the [area] to
  * @return the converted area
- * @exception IllegalArgumentException if the given units are invalid, or if the area is negative
+ * @throws IllegalArgumentException if the given units are invalid, or if the area is negative
  */
-@Suppress("ThrowsCount")
 @ExperimentalTurfApi
 public fun convertArea(
     area: Double,
@@ -100,7 +99,6 @@ public fun convertArea(
  * @param bearing angle, between -180 and +180 degrees
  * @return angle between 0 and 360 degrees
  */
-@Suppress("MagicNumber")
 @ExperimentalTurfApi
 public fun bearingToAzimuth(bearing: Double): Double {
     var angle = bearing % 360

--- a/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Utils.kt
+++ b/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/Utils.kt
@@ -1,4 +1,8 @@
+@file:JvmName("TurfUtils")
+
 package org.maplibre.spatialk.turf
+
+import kotlin.jvm.JvmName
 
 /**
  * Convert a distance measurement (assuming a spherical Earth) from radians to a more friendly unit.

--- a/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/BboxTests.kt
+++ b/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/BboxTests.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MagicNumber")
-
 package org.maplibre.spatialk.turf
 
 import kotlin.test.Test

--- a/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/BooleansTests.kt
+++ b/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/BooleansTests.kt
@@ -85,7 +85,6 @@ class BooleansTests {
     }
 
     @Test
-    @Suppress("LongMethod")
     fun testBoundaryTest() {
         val poly1 = polygon {
             ring {

--- a/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/TurfMeasurementTest.kt
+++ b/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/TurfMeasurementTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MagicNumber")
-
 package org.maplibre.spatialk.turf
 
 import kotlin.test.Test

--- a/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/TurfMiscTest.kt
+++ b/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/TurfMiscTest.kt
@@ -1,4 +1,4 @@
-package io.github.dellisd.spatialk.turf
+package org.maplibre.spatialk.turf
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -8,15 +8,10 @@ import org.maplibre.spatialk.geojson.MultiLineString
 import org.maplibre.spatialk.geojson.Point
 import org.maplibre.spatialk.geojson.Position
 import org.maplibre.spatialk.testutil.readResourceFile
-import org.maplibre.spatialk.turf.ExperimentalTurfApi
-import org.maplibre.spatialk.turf.lineIntersect
-import org.maplibre.spatialk.turf.lineSlice
-import org.maplibre.spatialk.turf.nearestPointOnLine
 import org.maplibre.spatialk.turf.utils.assertDoubleEquals
 import org.maplibre.spatialk.turf.utils.assertPositionEquals
 
 @ExperimentalTurfApi
-@Suppress("MagicNumber")
 class TurfMiscTest {
 
     @Test

--- a/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/UtilsTests.kt
+++ b/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/UtilsTests.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MagicNumber")
-
 package org.maplibre.spatialk.turf
 
 import kotlin.test.Test
@@ -52,7 +50,6 @@ class UtilsTests {
     }
 
     @Test
-    @Suppress("LongMethod")
     fun testConvertArea() {
         assertEquals(0.001, convertArea(1000.0))
         assertEquals(0.386, convertArea(1.0, from = Units.Kilometers, to = Units.Miles))


### PR DESCRIPTION
- to remove IDE noise, I went through every file and cleaned up the squiggles. This is mostly grammar nits, but also some minor code tweaks like unnecessary imports, redundant if, and so on
- I removed unnecessary `@Suppress` annotations for Detekt lints (we're not running Detekt rn)
- Removed unnecessary `@JsonIgnoreUnknownKeys` as we now configure it in `GeoJson`, and fixed some places where we didn't use `GeoJson`
- (breaking) Some Turf classes had `@JvmName` and some did not. I standardized the naming pattern.
- (breaking) Replaced a weird `@JvmName` with hyphen pattern in the DSL (not intended to be used from Java) with `@JvmSynthetic`
- Some other minor documentation tweaks