### PR TITLE
make `@OptIn` explicit

### DIFF
--- a/geojson/build.gradle.kts
+++ b/geojson/build.gradle.kts
@@ -65,15 +65,6 @@ kotlin {
     watchosDeviceArm64()
 
     sourceSets {
-        all {
-            with(languageSettings) {
-                optIn("kotlin.RequiresOptIn")
-                optIn("kotlin.js.ExperimentalJsExport")
-                optIn("kotlinx.serialization.InternalSerializationApi")
-                optIn("kotlinx.serialization.ExperimentalSerializationApi")
-            }
-        }
-
         commonMain {
             dependencies {
                 implementation(libs.jetbrains.annotations)

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/FeatureCollection.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/FeatureCollection.kt
@@ -3,7 +3,6 @@ package org.maplibre.spatialk.geojson
 import kotlin.jvm.JvmStatic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import org.intellij.lang.annotations.Language
 import org.maplibre.spatialk.geojson.serialization.GeoJson
 
@@ -17,7 +16,6 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  *   https://tools.ietf.org/html/rfc7946#section-3.2</a>
  */
 @Serializable
-@JsonIgnoreUnknownKeys
 @SerialName("FeatureCollection")
 public class FeatureCollection(
     public val features: List<Feature> = emptyList(),

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/GeoJsonObject.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/GeoJsonObject.kt
@@ -3,7 +3,6 @@ package org.maplibre.spatialk.geojson
 import kotlin.jvm.JvmStatic
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import org.intellij.lang.annotations.Language
 import org.maplibre.spatialk.geojson.serialization.GeoJson
 
@@ -14,7 +13,6 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  * @property bbox An optional bounding box used to represent the limits of the object's geometry.
  */
 @Serializable
-@JsonIgnoreUnknownKeys
 public sealed interface GeoJsonObject {
     public val bbox: BoundingBox?
 

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Geometry.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Geometry.kt
@@ -1,6 +1,7 @@
 package org.maplibre.spatialk.geojson
 
 import kotlin.jvm.JvmStatic
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonClassDiscriminator
 import org.intellij.lang.annotations.Language
@@ -14,6 +15,7 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  * @see GeometryCollection
  */
 @Serializable
+@OptIn(ExperimentalSerializationApi::class)
 @JsonClassDiscriminator("type")
 public sealed class Geometry() : GeoJsonObject {
     abstract override val bbox: BoundingBox?

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPoint.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPoint.kt
@@ -4,7 +4,6 @@ import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import org.intellij.lang.annotations.Language
 import org.maplibre.spatialk.geojson.serialization.GeoJson
 
@@ -15,7 +14,6 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("MultiPoint")
-@JsonIgnoreUnknownKeys
 public class MultiPoint
 @JvmOverloads
 constructor(

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPolygon.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPolygon.kt
@@ -4,7 +4,6 @@ import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import org.intellij.lang.annotations.Language
 import org.maplibre.spatialk.geojson.serialization.GeoJson
 
@@ -16,7 +15,6 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("MultiPolygon")
-@JsonIgnoreUnknownKeys
 public class MultiPolygon
 @JvmOverloads
 constructor(

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Point.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Point.kt
@@ -4,7 +4,6 @@ import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import org.intellij.lang.annotations.Language
 import org.maplibre.spatialk.geojson.serialization.GeoJson
 
@@ -15,7 +14,6 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("Point")
-@JsonIgnoreUnknownKeys
 public class Point
 @JvmOverloads
 constructor(public val coordinates: Position, override val bbox: BoundingBox? = null) : Geometry() {

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Polygon.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Polygon.kt
@@ -4,7 +4,6 @@ import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import org.intellij.lang.annotations.Language
 import org.maplibre.spatialk.geojson.serialization.GeoJson
 
@@ -26,7 +25,6 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("Polygon")
-@JsonIgnoreUnknownKeys
 public class Polygon
 @JvmOverloads
 constructor(

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/serialization/BoundingBoxSerializer.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/serialization/BoundingBoxSerializer.kt
@@ -1,5 +1,6 @@
 package org.maplibre.spatialk.geojson.serialization
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
@@ -14,6 +15,7 @@ public object BoundingBoxSerializer : KSerializer<BoundingBox> {
     private const val ARRAY_SIZE_2D = 4
     private const val ARRAY_SIZE_3D = 6
 
+    @OptIn(ExperimentalSerializationApi::class)
     override val descriptor: SerialDescriptor = listSerialDescriptor(Double.serializer().descriptor)
 
     override fun deserialize(decoder: Decoder): BoundingBox {

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/serialization/GeoJson.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/serialization/GeoJson.kt
@@ -1,9 +1,11 @@
 package org.maplibre.spatialk.geojson.serialization
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.ClassDiscriminatorMode
 import kotlinx.serialization.json.Json
 
 public val GeoJson: Json = Json {
+    @OptIn(ExperimentalSerializationApi::class)
     classDiscriminatorMode = ClassDiscriminatorMode.ALL_JSON_OBJECTS
     ignoreUnknownKeys = true
 }

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/serialization/PositionSerializer.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/serialization/PositionSerializer.kt
@@ -1,5 +1,6 @@
 package org.maplibre.spatialk.geojson.serialization
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
@@ -18,6 +19,7 @@ import org.maplibre.spatialk.geojson.Position
  * A position's [altitude][Position.altitude] is only included in the array if it is not null.
  */
 public object PositionSerializer : KSerializer<Position> {
+    @OptIn(ExperimentalSerializationApi::class)
     override val descriptor: SerialDescriptor = listSerialDescriptor(Double.serializer().descriptor)
 
     override fun deserialize(decoder: Decoder): Position {

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/DocSnippets.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/DocSnippets.kt
@@ -5,6 +5,7 @@ package org.maplibre.spatialk.geojson
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import org.intellij.lang.annotations.Language
@@ -37,7 +38,10 @@ class DocSnippets {
     }
 
     private inline fun kotlinAndJsonExample(kotlin: () -> String, @Language("json5") json: String) {
-        val jsonC = Json { allowComments = true }
+        val jsonC = Json {
+            @OptIn(ExperimentalSerializationApi::class)
+            allowComments = true
+        }
         // round trip to normalize property order across platforms
         val normalizedJsonExample = jsonC.encodeToString(jsonC.parseToJsonElement(json))
         val normalizedKotlinExample = jsonC.encodeToString(jsonC.parseToJsonElement(kotlin()))

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/serialization/FormatTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/serialization/FormatTest.kt
@@ -3,6 +3,7 @@ package org.maplibre.spatialk.geojson.serialization
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.cbor.Cbor
 import kotlinx.serialization.protobuf.ProtoBuf
 import org.maplibre.spatialk.geojson.GeometryCollection
@@ -55,6 +56,7 @@ class ProtoBufSerializationTests {
     @Test
     fun testProtoBufSerialization() {
         assertFormat { obj ->
+            @OptIn(ExperimentalSerializationApi::class)
             ProtoBuf.decodeFromByteArray(
                 GeometryCollection.serializer(),
                 ProtoBuf.encodeToByteArray(GeometryCollection.serializer(), obj),
@@ -65,6 +67,7 @@ class ProtoBufSerializationTests {
     @Test
     fun testCborSerialization() {
         assertFormat { obj ->
+            @OptIn(ExperimentalSerializationApi::class)
             Cbor.decodeFromByteArray(
                 GeometryCollection.serializer(),
                 Cbor.encodeToByteArray(GeometryCollection.serializer(), obj),

--- a/turf/build.gradle.kts
+++ b/turf/build.gradle.kts
@@ -57,8 +57,6 @@ kotlin {
     watchosDeviceArm64()
 
     sourceSets {
-        all { with(languageSettings) { optIn("kotlin.RequiresOptIn") } }
-
         commonMain.dependencies {
             api(project(":geojson"))
             api(project(":units"))

--- a/units/build.gradle.kts
+++ b/units/build.gradle.kts
@@ -57,8 +57,6 @@ kotlin {
     watchosDeviceArm64()
 
     sourceSets {
-        all { with(languageSettings) { optIn("kotlin.RequiresOptIn") } }
-
         commonTest.dependencies {
             implementation(kotlin("test"))
             implementation(kotlin("test-annotations-common"))


### PR DESCRIPTION
for clarity where we're using experimental APIs (turns out most of the opt in flags were unnecessary)