### PR TITLE
data classes for GeoJsonObject children

### DIFF
--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Feature.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Feature.kt
@@ -20,52 +20,13 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("Feature")
-public class Feature(
+public data class Feature(
     public val geometry: Geometry?,
     public val properties: JsonObject? = null,
     public val id: String? = null,
     override val bbox: BoundingBox? = null,
 ) : GeoJsonObject {
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as Feature
-
-        if (geometry != other.geometry) return false
-        if (id != other.id) return false
-        if (bbox != other.bbox) return false
-        if (properties != other.properties) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = geometry?.hashCode() ?: 0
-        result = 31 * result + (id?.hashCode() ?: 0)
-        result = 31 * result + (bbox?.hashCode() ?: 0)
-        result = 31 * result + properties.hashCode()
-        return result
-    }
-
-    public operator fun component1(): Geometry? = geometry
-
-    public operator fun component2(): JsonObject? = properties
-
-    public operator fun component3(): String? = id
-
-    public operator fun component4(): BoundingBox? = bbox
-
-    override fun toString(): String = json()
-
     override fun json(): String = GeoJson.encodeToString(this)
-
-    public fun copy(
-        geometry: Geometry? = this.geometry,
-        properties: JsonObject? = this.properties,
-        id: String? = this.id,
-        bbox: BoundingBox? = this.bbox,
-    ): Feature = Feature(geometry, properties, id, bbox)
 
     public companion object {
         @JvmStatic

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/FeatureCollection.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/FeatureCollection.kt
@@ -17,7 +17,7 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("FeatureCollection")
-public class FeatureCollection(
+public data class FeatureCollection(
     public val features: List<Feature> = emptyList(),
     override val bbox: BoundingBox? = null,
 ) : Collection<Feature> by features, GeoJsonObject {
@@ -26,31 +26,7 @@ public class FeatureCollection(
         bbox: BoundingBox? = null,
     ) : this(features.toMutableList(), bbox)
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as FeatureCollection
-
-        if (features != other.features) return false
-        if (bbox != other.bbox) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = features.hashCode()
-        result = 31 * result + (bbox?.hashCode() ?: 0)
-        return result
-    }
-
-    override fun toString(): String = json()
-
     override fun json(): String = GeoJson.encodeToString(this)
-
-    public operator fun component1(): List<Feature> = features
-
-    public operator fun component2(): BoundingBox? = bbox
 
     public companion object {
         @JvmStatic

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/GeometryCollection.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/GeometryCollection.kt
@@ -14,33 +14,16 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("GeometryCollection")
-public class GeometryCollection
+public data class GeometryCollection
 @JvmOverloads
 constructor(public val geometries: List<Geometry>, override val bbox: BoundingBox? = null) :
     Geometry(), Collection<Geometry> by geometries {
+
     @JvmOverloads
     public constructor(
         vararg geometries: Geometry,
         bbox: BoundingBox? = null,
     ) : this(geometries.toList(), bbox)
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as GeometryCollection
-
-        if (geometries != other.geometries) return false
-        if (bbox != other.bbox) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = geometries.hashCode()
-        result = 31 * result + (bbox?.hashCode() ?: 0)
-        return result
-    }
 
     override fun json(): String = GeoJson.encodeToString(this)
 

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/LineString.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/LineString.kt
@@ -15,7 +15,7 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("LineString")
-public class LineString
+public data class LineString
 @JvmOverloads
 constructor(
     /** a list of [Position]s. */
@@ -60,24 +60,6 @@ constructor(
 
     init {
         require(coordinates.size >= 2) { "LineString must contain at least two positions" }
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as LineString
-
-        if (coordinates != other.coordinates) return false
-        if (bbox != other.bbox) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = coordinates.hashCode()
-        result = 31 * result + (bbox?.hashCode() ?: 0)
-        return result
     }
 
     override fun json(): String = GeoJson.encodeToString(this)

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiLineString.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiLineString.kt
@@ -15,7 +15,7 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("MultiLineString")
-public class MultiLineString
+public data class MultiLineString
 @JvmOverloads
 constructor(public val coordinates: List<List<Position>>, override val bbox: BoundingBox? = null) :
     Geometry() {
@@ -57,24 +57,6 @@ constructor(public val coordinates: List<List<Position>>, override val bbox: Bou
                 "LineString at index $index contains fewer than 2 positions."
             }
         }
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as MultiLineString
-
-        if (coordinates != other.coordinates) return false
-        if (bbox != other.bbox) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = coordinates.hashCode()
-        result = 31 * result + (bbox?.hashCode() ?: 0)
-        return result
     }
 
     override fun json(): String = GeoJson.encodeToString(this)

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPoint.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPoint.kt
@@ -14,7 +14,7 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("MultiPoint")
-public class MultiPoint
+public data class MultiPoint
 @JvmOverloads
 constructor(
     /** a list of [Position]s. */
@@ -40,24 +40,6 @@ constructor(
         coordinates: Array<DoubleArray>,
         bbox: BoundingBox? = null,
     ) : this(coordinates.map(::Position), bbox)
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as MultiPoint
-
-        if (coordinates != other.coordinates) return false
-        if (bbox != other.bbox) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = coordinates.hashCode()
-        result = 31 * result + (bbox?.hashCode() ?: 0)
-        return result
-    }
 
     override fun json(): String = GeoJson.encodeToString(this)
 

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPolygon.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/MultiPolygon.kt
@@ -15,7 +15,7 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("MultiPolygon")
-public class MultiPolygon
+public data class MultiPolygon
 @JvmOverloads
 constructor(
     /** a list (= polygons) of lists (= polygon rings) of lists of [Position]s. */
@@ -69,24 +69,6 @@ constructor(
                 }
             }
         }
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as MultiPolygon
-
-        if (coordinates != other.coordinates) return false
-        if (bbox != other.bbox) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = coordinates.hashCode()
-        result = 31 * result + (bbox?.hashCode() ?: 0)
-        return result
     }
 
     override fun json(): String = GeoJson.encodeToString(this)

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Point.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Point.kt
@@ -14,7 +14,7 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("Point")
-public class Point
+public data class Point
 @JvmOverloads
 constructor(public val coordinates: Position, override val bbox: BoundingBox? = null) : Geometry() {
     @JvmOverloads
@@ -29,24 +29,6 @@ constructor(public val coordinates: Position, override val bbox: BoundingBox? = 
         altitude: Double? = null,
         bbox: BoundingBox? = null,
     ) : this(Position(longitude, latitude, altitude), bbox)
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as Point
-
-        if (coordinates != other.coordinates) return false
-        if (bbox != other.bbox) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = coordinates.hashCode()
-        result = 31 * result + (bbox?.hashCode() ?: 0)
-        return result
-    }
 
     override fun json(): String = GeoJson.encodeToString(this)
 

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Polygon.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Polygon.kt
@@ -25,7 +25,7 @@ import org.maplibre.spatialk.geojson.serialization.GeoJson
  */
 @Serializable
 @SerialName("Polygon")
-public class Polygon
+public data class Polygon
 @JvmOverloads
 constructor(
     /**
@@ -75,24 +75,6 @@ constructor(
             require(ring.size >= 4) { "Line string at index $i contains fewer than 4 positions." }
             require(ring.first() == ring.last()) { "Line string at at index $i is not closed." }
         }
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as Polygon
-
-        if (coordinates != other.coordinates) return false
-        if (bbox != other.bbox) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = coordinates.hashCode()
-        result = 31 * result + (bbox?.hashCode() ?: 0)
-        return result
     }
 
     override fun json(): String = GeoJson.encodeToString(this)


### PR DESCRIPTION
This PR uses data classes wherever our existing `equals` and `hashCode` are equivalent. Should be no changes in functionality (except `toString` format, because the old one delegated to `json()`

I didn't change `Position` or `BoundingBox`, assuming the `DoubleArray` optimization there is something to keep. Will evaluate in another PR.

#200 