### PR TITLE
set up semver gradle plugin for automatic version based on git tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
               with:
                   distribution: temurin
                   java-version: 21
+            - run: ./gradlew printSemver # TODO: remove this once we're confident in our config
             - run: ./gradlew ${{ matrix.task }}
             - if: ${{ matrix.task == 'build' }} # Kover only supports JVM
               name: Generate coverage summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,11 @@
 name: Publish Release
 
 on:
-    push:
-        tags:
-            - "v*"
+    workflow_dispatch:
+    # TODO: temporarily disabled so I can push old tags without releasing anything
+    # push:
+    #     tags:
+    #         - "v*"
 
 permissions:
     contents: read

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(libs.gradle.publish)
     implementation(libs.gradle.benchmark)
     implementation(libs.gradle.kover)
+    implementation(libs.gradle.semver)
 }
 
 kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_1_8 } }

--- a/buildSrc/src/main/kotlin/published-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/published-library.gradle.kts
@@ -3,9 +3,9 @@ import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 plugins {
     id("base-module")
     id("org.jetbrains.dokka")
-    id("com.javiersc.semver")
     id("com.vanniktech.maven.publish")
     id("org.jetbrains.kotlinx.kover")
+    id("com.javiersc.semver")
 }
 
 group = "org.maplibre.spatialk"
@@ -25,8 +25,7 @@ dokka {
         configureEach {
             includes.from("MODULE.md")
             sourceLink {
-                // TODO link to version (git tag) using jgitver
-                remoteUrl("https://github.com/maplibre/spatial-k/tree/main/")
+                remoteUrl("https://github.com/maplibre/spatial-k/tree/${project.version}/")
                 localDirectory = rootDir
             }
             externalDocumentationLinks {

--- a/buildSrc/src/main/kotlin/published-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/published-library.gradle.kts
@@ -3,9 +3,14 @@ import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 plugins {
     id("base-module")
     id("org.jetbrains.dokka")
+    id("com.javiersc.semver")
     id("com.vanniktech.maven.publish")
     id("org.jetbrains.kotlinx.kover")
 }
+
+group = "org.maplibre.spatialk"
+
+semver { tagPrefix = "v" }
 
 kotlin {
     explicitApi()

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,9 +7,6 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 mavenCentralPublishing=true
 signAllPublications=true
 
-GROUP=org.maplibre.spatialk
-VERSION_NAME=0.4.0-SNAPSHOT
-
 POM_URL=https://github.com/maplibre/spatial-k
 
 POM_LICENCE_NAME=MIT License

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ kotlinx-serialization = "1.9.0"
 vanniktech-publish = "0.34.0"
 dokka = "2.1.0-Beta"
 kotlinx-io = "0.8.0"
+semver = "0.8.0"
 
 [libraries]
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref="jetbrains-annotations"}
@@ -21,3 +22,4 @@ gradle-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref
 gradle-publish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "vanniktech-publish" }
 gradle-benchmark = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-plugin", version.ref = "kotlinx-benchmark" }
 gradle-kover = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kotlinx-kover" }
+gradle-semver = { module = "com.javiersc.semver:com.javiersc.semver.gradle.plugin", version.ref = "semver" }


### PR DESCRIPTION
part 1 of #197 (but I chose to try a different plugin than what I usually use)

part 2 will set up the mkdocs gradle plugin and use this to automatically update the version mentioned in the installation instructions.

Other than this PR, we'll need to push all past tags with the `v` prefix added (well, at least v0.3.0) for snapshots (see #196) to have the right version. I disabled the release trigger so I can push those tags without triggering releases.