### PR TITLE
restore property retrieval convenience functions

### DIFF
--- a/geojson/api/geojson.api
+++ b/geojson/api/geojson.api
@@ -35,21 +35,29 @@ public final class org/maplibre/spatialk/geojson/BoundingBox$Companion {
 
 public final class org/maplibre/spatialk/geojson/Feature : org/maplibre/spatialk/geojson/GeoJsonObject {
 	public static final field Companion Lorg/maplibre/spatialk/geojson/Feature$Companion;
+	public fun <init> (Lorg/maplibre/spatialk/geojson/Geometry;)V
+	public fun <init> (Lorg/maplibre/spatialk/geojson/Geometry;Lkotlinx/serialization/json/JsonObject;)V
+	public fun <init> (Lorg/maplibre/spatialk/geojson/Geometry;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)V
 	public fun <init> (Lorg/maplibre/spatialk/geojson/Geometry;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lorg/maplibre/spatialk/geojson/BoundingBox;)V
 	public synthetic fun <init> (Lorg/maplibre/spatialk/geojson/Geometry;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lorg/maplibre/spatialk/geojson/BoundingBox;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lorg/maplibre/spatialk/geojson/Geometry;
 	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Lorg/maplibre/spatialk/geojson/BoundingBox;
+	public final fun containsProperty (Ljava/lang/String;)Z
 	public final fun copy (Lorg/maplibre/spatialk/geojson/Geometry;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lorg/maplibre/spatialk/geojson/BoundingBox;)Lorg/maplibre/spatialk/geojson/Feature;
 	public static synthetic fun copy$default (Lorg/maplibre/spatialk/geojson/Feature;Lorg/maplibre/spatialk/geojson/Geometry;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lorg/maplibre/spatialk/geojson/BoundingBox;ILjava/lang/Object;)Lorg/maplibre/spatialk/geojson/Feature;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lorg/maplibre/spatialk/geojson/Feature;
 	public static final fun fromJsonOrNull (Ljava/lang/String;)Lorg/maplibre/spatialk/geojson/Feature;
 	public fun getBbox ()Lorg/maplibre/spatialk/geojson/BoundingBox;
+	public final fun getBooleanProperty (Ljava/lang/String;)Ljava/lang/Boolean;
+	public final fun getDoubleProperty (Ljava/lang/String;)Ljava/lang/Double;
 	public final fun getGeometry ()Lorg/maplibre/spatialk/geojson/Geometry;
 	public final fun getId ()Ljava/lang/String;
+	public final fun getIntProperty (Ljava/lang/String;)Ljava/lang/Integer;
 	public final fun getProperties ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getStringProperty (Ljava/lang/String;)Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toJson ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
@@ -75,6 +83,7 @@ public final class org/maplibre/spatialk/geojson/Feature$Companion {
 public final class org/maplibre/spatialk/geojson/FeatureCollection : java/util/Collection, kotlin/jvm/internal/markers/KMappedMarker, org/maplibre/spatialk/geojson/GeoJsonObject {
 	public static final field Companion Lorg/maplibre/spatialk/geojson/FeatureCollection$Companion;
 	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
 	public fun <init> (Ljava/util/List;Lorg/maplibre/spatialk/geojson/BoundingBox;)V
 	public synthetic fun <init> (Ljava/util/List;Lorg/maplibre/spatialk/geojson/BoundingBox;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> ([Lorg/maplibre/spatialk/geojson/Feature;Lorg/maplibre/spatialk/geojson/BoundingBox;)V

--- a/geojson/api/geojson.klib.api
+++ b/geojson/api/geojson.klib.api
@@ -63,8 +63,13 @@ final class <#A: out org.maplibre.spatialk.geojson/Geometry> org.maplibre.spatia
     final fun component2(): kotlinx.serialization.json/JsonObject? // org.maplibre.spatialk.geojson/Feature.component2|component2(){}[0]
     final fun component3(): kotlin/String? // org.maplibre.spatialk.geojson/Feature.component3|component3(){}[0]
     final fun component4(): org.maplibre.spatialk.geojson/BoundingBox? // org.maplibre.spatialk.geojson/Feature.component4|component4(){}[0]
+    final fun containsProperty(kotlin/String): kotlin/Boolean // org.maplibre.spatialk.geojson/Feature.containsProperty|containsProperty(kotlin.String){}[0]
     final fun copy(#A? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ..., org.maplibre.spatialk.geojson/BoundingBox? = ...): org.maplibre.spatialk.geojson/Feature<#A> // org.maplibre.spatialk.geojson/Feature.copy|copy(1:0?;kotlinx.serialization.json.JsonObject?;kotlin.String?;org.maplibre.spatialk.geojson.BoundingBox?){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // org.maplibre.spatialk.geojson/Feature.equals|equals(kotlin.Any?){}[0]
+    final fun getBooleanProperty(kotlin/String): kotlin/Boolean? // org.maplibre.spatialk.geojson/Feature.getBooleanProperty|getBooleanProperty(kotlin.String){}[0]
+    final fun getDoubleProperty(kotlin/String): kotlin/Double? // org.maplibre.spatialk.geojson/Feature.getDoubleProperty|getDoubleProperty(kotlin.String){}[0]
+    final fun getIntProperty(kotlin/String): kotlin/Int? // org.maplibre.spatialk.geojson/Feature.getIntProperty|getIntProperty(kotlin.String){}[0]
+    final fun getStringProperty(kotlin/String): kotlin/String? // org.maplibre.spatialk.geojson/Feature.getStringProperty|getStringProperty(kotlin.String){}[0]
     final fun hashCode(): kotlin/Int // org.maplibre.spatialk.geojson/Feature.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // org.maplibre.spatialk.geojson/Feature.toString|toString(){}[0]
 

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Feature.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Feature.kt
@@ -1,12 +1,15 @@
 package org.maplibre.spatialk.geojson
 
 import kotlin.jvm.JvmName
+import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
 
 /**
  * A feature object represents a spatially bounded thing.
@@ -21,7 +24,9 @@ import kotlinx.serialization.json.JsonObject
  */
 @Serializable
 @SerialName("Feature")
-public data class Feature<out T : Geometry>(
+public data class Feature<out T : Geometry>
+@JvmOverloads
+constructor(
     // It would be ideal if nullability was expressed in the generic T, but kotlinx.serialization
     // doesn't support that. See https://github.com/Kotlin/kotlinx.serialization/issues/2828.
     public val geometry: T?,
@@ -29,6 +34,20 @@ public data class Feature<out T : Geometry>(
     public val id: String? = null,
     override val bbox: BoundingBox? = null,
 ) : GeoJsonObject {
+
+    public fun containsProperty(key: String): Boolean = properties?.containsKey(key) ?: false
+
+    public fun getStringProperty(key: String): String? =
+        properties?.get(key)?.let { Json.decodeFromJsonElement(it) }
+
+    public fun getDoubleProperty(key: String): Double? =
+        properties?.get(key)?.let { Json.decodeFromJsonElement(it) }
+
+    public fun getIntProperty(key: String): Int? =
+        properties?.get(key)?.let { Json.decodeFromJsonElement(it) }
+
+    public fun getBooleanProperty(key: String): Boolean? =
+        properties?.get(key)?.let { Json.decodeFromJsonElement(it) }
 
     public companion object {
         @JvmSynthetic // See below for Java-facing API

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/FeatureCollection.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/FeatureCollection.kt
@@ -1,5 +1,6 @@
 package org.maplibre.spatialk.geojson
 
+import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -16,7 +17,9 @@ import org.intellij.lang.annotations.Language
  */
 @Serializable
 @SerialName("FeatureCollection")
-public data class FeatureCollection(
+public data class FeatureCollection
+@JvmOverloads
+constructor(
     public val features: List<Feature<*>> = emptyList(),
     override val bbox: BoundingBox? = null,
 ) : Collection<Feature<*>> by features, GeoJsonObject {

--- a/geojson/src/jvmTest/java/org/maplibre/spatialk/geojson/JavaDocsTest.java
+++ b/geojson/src/jvmTest/java/org/maplibre/spatialk/geojson/JavaDocsTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 
 import kotlinx.serialization.SerializationException;
-import kotlinx.serialization.json.JsonElement;
 import kotlinx.serialization.json.JsonElementBuildersKt;
 import kotlinx.serialization.json.JsonObjectBuilder;
 import org.junit.Test;
@@ -112,11 +111,12 @@ public class JavaDocsTest {
   public void featureExample() {
     // --8<-- [start:featureJava]
     Point point = new Point(new Position(-75.0, 45.0));
+
     JsonObjectBuilder properties = new JsonObjectBuilder();
     JsonElementBuildersKt.put(properties, "size", 9999);
     Feature<Point> feature = new Feature<>(point, properties.build(), null, null);
 
-    JsonElement size = feature.getProperties().get("size");
+    Integer size = feature.getIntProperty("size");
     Point geometry = feature.getGeometry(); // point
     // --8<-- [end:featureJava]
   }


### PR DESCRIPTION
We previously had these helpers methods, but I removed them in a previous PR.

Adding them back because working with `JsonObject` directly in Java is not ergonomic.

Related: #209 