### PR TITLE
Format-agnostic property serializer

### DIFF
--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Feature.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Feature.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import org.intellij.lang.annotations.Language
 import org.maplibre.spatialk.geojson.serialization.FeatureGeometrySerializer
+import org.maplibre.spatialk.geojson.serialization.FeaturePropertiesSerializer
 
 /**
  * A feature object represents a spatially bounded thing.
@@ -32,6 +33,7 @@ constructor(
     @Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
     @Serializable(with = FeatureGeometrySerializer::class)
     public val geometry: T,
+    @Serializable(with = FeaturePropertiesSerializer::class)
     public val properties: JsonObject? = null,
     public val id: String? = null,
     override val bbox: BoundingBox? = null,

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/serialization/FeaturePropertiesSerializer.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/serialization/FeaturePropertiesSerializer.kt
@@ -1,0 +1,29 @@
+package org.maplibre.spatialk.geojson.serialization
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+
+internal object FeaturePropertiesSerializer : KSerializer<JsonObject> {
+    private val delegate = JsonObject.serializer()
+
+    override val descriptor: SerialDescriptor = delegate.descriptor
+
+    override fun deserialize(decoder: Decoder): JsonObject {
+        return when (decoder) {
+            is JsonDecoder -> delegate.deserialize(decoder)
+            else -> Json.decodeFromString(delegate, decoder.decodeString())
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: JsonObject): Unit =
+        when (encoder) {
+            is JsonEncoder -> delegate.serialize(encoder, value)
+            else -> encoder.encodeString(Json.encodeToString(delegate, value))
+        }
+}


### PR DESCRIPTION
Adds a custom property serializer that stores properties as a JSON string for non-JSON formats

As far as I can tell, there's no support for `Any`-like structures in Protobuf, so this seems like the next best thing

I also experimented with [making properties generic](https://github.com/jgillich/spatial-k/tree/generic-properties), but that seems to be impossible, it'll look for a `Any` serializer and I haven't found a way to override it globally