### PR TITLE
ci: pin mise to 2026.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
               with:
                   persist-credentials: false
             - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+              with:
+                  version: 2026.6.0
             - run: ./gradlew version # TODO: remove this once we're confident in our config
             - run: ./gradlew "${{ matrix.task }}"
             - if: ${{ matrix.task == 'macosArm64Test' }}
@@ -45,6 +47,8 @@ jobs:
               with:
                   persist-credentials: false
             - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+              with:
+                  version: 2026.6.0
             - name: Run benchmark
               run: |
                   echo '## Benchmark' >> "$GITHUB_STEP_SUMMARY"
@@ -57,6 +61,8 @@ jobs:
               with:
                   persist-credentials: false
             - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+              with:
+                  version: 2026.6.0
             - run: mise run docs:build --version dev
             - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
               with:
@@ -69,6 +75,8 @@ jobs:
               with:
                   persist-credentials: false
             - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+              with:
+                  version: 2026.6.0
             - run: mise run check
 
     check-integrity:
@@ -78,6 +86,8 @@ jobs:
               with:
                   persist-credentials: false
             - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+              with:
+                  version: 2026.6.0
             - name: Verify gradle wrapper
               run: |
                   GRADLE_VERSION=$(grep distributionUrl gradle/wrapper/gradle-wrapper.properties \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,6 +72,8 @@ jobs:
               with:
                   persist-credentials: false
             - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+              with:
+                  version: 2026.6.0
             - id: version
               run: |
                   latest_release=""
@@ -108,6 +110,8 @@ jobs:
               with:
                   persist-credentials: false
             - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+              with:
+                  version: 2026.6.0
             - name: Publish
               run: >
                   mise run publish --mode live
@@ -141,6 +145,8 @@ jobs:
               with:
                   persist-credentials: false
             - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+              with:
+                  version: 2026.6.0
             - name: Build docs
               run: >
                   mise run docs:build --version
@@ -164,6 +170,8 @@ jobs:
               with:
                   persist-credentials: false
             - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+              with:
+                  version: 2026.6.0
             - name: Build SwiftPM binary artifact
               run: >
                   mise run publish:pmtiles-swift


### PR DESCRIPTION
mise 2026.6.1 introduced a regression where a `[hooks] postinstall` array of exactly 3 strings is positionally deserialized into the `Run(HookRunTable)` struct (run, run_windows, shell) instead of an array of run strings. The middle element is silently dropped on Linux, so `pnpm install` never runs, node_modules is never created, and `docs:build` fails with `Command "astro" not found`.

