### PR TITLE
Add tests for extra GeoJSON coordinate axes

### DIFF
--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/ExtraAxesTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/ExtraAxesTest.kt
@@ -32,9 +32,11 @@ class ExtraAxesTest {
         val northeast = Position(4.0, 5.0, 6.0, 8.0)
         val boundingBox = BoundingBox(southwest, northeast)
 
+        assertEquals(8, boundingBox.size)
+        assertEquals(4, boundingBox.southwest.size)
+        assertEquals(4, boundingBox.northeast.size)
         assertEquals(southwest, boundingBox.southwest)
         assertEquals(northeast, boundingBox.northeast)
-        assertEquals(8, boundingBox.size)
     }
 
     @Test
@@ -44,6 +46,8 @@ class ExtraAxesTest {
 
         assertJsonEquals("[1.0, 2.0, 3.0, 7.0, 4.0, 5.0, 6.0, 8.0]", boundingBox.toJson())
         assertEquals(boundingBox, decoded)
+        assertEquals(4, decoded.southwest.size)
+        assertEquals(4, decoded.northeast.size)
         assertEquals(Position(1.0, 2.0, 3.0, 7.0), decoded.southwest)
         assertEquals(Position(4.0, 5.0, 6.0, 8.0), decoded.northeast)
     }

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/ExtraAxesTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/ExtraAxesTest.kt
@@ -5,6 +5,7 @@ package org.maplibre.spatialk.geojson
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.maplibre.spatialk.geojson.utils.assertJsonEquals
+import org.maplibre.spatialk.testutil.assertDoubleEquals
 
 class ExtraAxesTest {
     @Test
@@ -12,10 +13,10 @@ class ExtraAxesTest {
         val position = Position(-75.0, 45.0, 100.0, 1.5)
 
         assertEquals(4, position.size)
-        assertEquals(-75.0, position.longitude)
-        assertEquals(45.0, position.latitude)
-        assertEquals(100.0, position.altitude)
-        assertEquals(1.5, position[3])
+        assertDoubleEquals(-75.0, position.longitude)
+        assertDoubleEquals(45.0, position.latitude)
+        assertDoubleEquals(100.0, position.altitude)
+        assertDoubleEquals(1.5, position[3])
     }
 
     @Test

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/ExtraAxesTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/ExtraAxesTest.kt
@@ -1,0 +1,61 @@
+@file:OptIn(SensitiveGeoJsonApi::class)
+
+package org.maplibre.spatialk.geojson
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.maplibre.spatialk.geojson.utils.assertJsonEquals
+
+class ExtraAxesTest {
+    @Test
+    fun position_preservesAdditionalElements() {
+        val position = Position(-75.0, 45.0, 100.0, 1.5)
+
+        assertEquals(4, position.size)
+        assertEquals(-75.0, position.longitude)
+        assertEquals(45.0, position.latitude)
+        assertEquals(100.0, position.altitude)
+        assertEquals(1.5, position[3])
+    }
+
+    @Test
+    fun position_jsonRoundTripPreservesAdditionalElements() {
+        val position = Position(-75.0, 45.0, 100.0, 1.5)
+
+        assertJsonEquals("[-75.0, 45.0, 100.0, 1.5]", position.toJson())
+        assertEquals(position, Position.fromJson(position.toJson()))
+    }
+
+    @Test
+    fun boundingBox_cornersPreserveAdditionalElements() {
+        val southwest = Position(1.0, 2.0, 3.0, 7.0)
+        val northeast = Position(4.0, 5.0, 6.0, 8.0)
+        val boundingBox = BoundingBox(southwest, northeast)
+
+        assertEquals(southwest, boundingBox.southwest)
+        assertEquals(northeast, boundingBox.northeast)
+        assertEquals(8, boundingBox.size)
+    }
+
+    @Test
+    fun boundingBox_jsonRoundTripPreservesAdditionalElements() {
+        val boundingBox = BoundingBox(Position(1.0, 2.0, 3.0, 7.0), Position(4.0, 5.0, 6.0, 8.0))
+        val decoded = BoundingBox.fromJson(boundingBox.toJson())
+
+        assertJsonEquals("[1.0, 2.0, 3.0, 7.0, 4.0, 5.0, 6.0, 8.0]", boundingBox.toJson())
+        assertEquals(boundingBox, decoded)
+        assertEquals(Position(1.0, 2.0, 3.0, 7.0), decoded.southwest)
+        assertEquals(Position(4.0, 5.0, 6.0, 8.0), decoded.northeast)
+    }
+
+    @Test
+    fun point_jsonRoundTripPreservesAdditionalElements() {
+        val point = Point(Position(100.0, 0.0, 200.0, 1.5))
+
+        assertJsonEquals(
+            """{"type":"Point","coordinates":[100.0, 0.0, 200.0, 1.5]}""",
+            point.toJson(),
+        )
+        assertEquals(point, Point.fromJson(point.toJson()))
+    }
+}

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/ExtraAxesTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/ExtraAxesTest.kt
@@ -4,33 +4,32 @@ package org.maplibre.spatialk.geojson
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import org.maplibre.spatialk.geojson.utils.assertJsonEquals
 import org.maplibre.spatialk.testutil.assertDoubleEquals
 
 class ExtraAxesTest {
     @Test
     fun position_preservesAdditionalElements() {
-        val position = Position(-75.0, 45.0, 100.0, 1.5)
+        val position = Position(-75.1, 45.1, 100.5, 1.5)
 
         assertEquals(4, position.size)
-        assertDoubleEquals(-75.0, position.longitude)
-        assertDoubleEquals(45.0, position.latitude)
-        assertDoubleEquals(100.0, position.altitude)
+        assertDoubleEquals(-75.1, position.longitude)
+        assertDoubleEquals(45.1, position.latitude)
+        assertDoubleEquals(100.5, position.altitude)
         assertDoubleEquals(1.5, position[3])
     }
 
     @Test
     fun position_jsonRoundTripPreservesAdditionalElements() {
-        val position = Position(-75.0, 45.0, 100.0, 1.5)
+        val position = Position(-75.1, 45.1, 100.5, 1.5)
 
-        assertJsonEquals("[-75.0, 45.0, 100.0, 1.5]", position.toJson())
+        assertEquals("[-75.1,45.1,100.5,1.5]", position.toJson())
         assertEquals(position, Position.fromJson(position.toJson()))
     }
 
     @Test
     fun boundingBox_cornersPreserveAdditionalElements() {
-        val southwest = Position(1.0, 2.0, 3.0, 7.0)
-        val northeast = Position(4.0, 5.0, 6.0, 8.0)
+        val southwest = Position(1.1, 2.2, 3.3, 7.7)
+        val northeast = Position(4.4, 5.5, 6.6, 8.8)
         val boundingBox = BoundingBox(southwest, northeast)
 
         assertEquals(8, boundingBox.size)
@@ -42,25 +41,22 @@ class ExtraAxesTest {
 
     @Test
     fun boundingBox_jsonRoundTripPreservesAdditionalElements() {
-        val boundingBox = BoundingBox(Position(1.0, 2.0, 3.0, 7.0), Position(4.0, 5.0, 6.0, 8.0))
+        val boundingBox = BoundingBox(Position(1.1, 2.2, 3.3, 7.7), Position(4.4, 5.5, 6.6, 8.8))
         val decoded = BoundingBox.fromJson(boundingBox.toJson())
 
-        assertJsonEquals("[1.0, 2.0, 3.0, 7.0, 4.0, 5.0, 6.0, 8.0]", boundingBox.toJson())
+        assertEquals("[1.1,2.2,3.3,7.7,4.4,5.5,6.6,8.8]", boundingBox.toJson())
         assertEquals(boundingBox, decoded)
         assertEquals(4, decoded.southwest.size)
         assertEquals(4, decoded.northeast.size)
-        assertEquals(Position(1.0, 2.0, 3.0, 7.0), decoded.southwest)
-        assertEquals(Position(4.0, 5.0, 6.0, 8.0), decoded.northeast)
+        assertEquals(Position(1.1, 2.2, 3.3, 7.7), decoded.southwest)
+        assertEquals(Position(4.4, 5.5, 6.6, 8.8), decoded.northeast)
     }
 
     @Test
     fun point_jsonRoundTripPreservesAdditionalElements() {
-        val point = Point(Position(100.0, 0.0, 200.0, 1.5))
+        val point = Point(Position(12.3, 45.6, 100.5, 1.5))
 
-        assertJsonEquals(
-            """{"type":"Point","coordinates":[100.0, 0.0, 200.0, 1.5]}""",
-            point.toJson(),
-        )
+        assertEquals("""{"type":"Point","coordinates":[12.3,45.6,100.5,1.5]}""", point.toJson())
         assertEquals(point, Point.fromJson(point.toJson()))
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#378 would have dropped extra axes from `BoundingBox.southwest` / `northeast`. We had no tests using the `@SensitiveGeoJsonApi` extra-axis constructors, so that would have shipped unnoticed if the review bot didn't catch it.

This adds a small `ExtraAxesTest` covering construction and JSON round-trip with an extra axis.

JSON assertions follow `SerializationTests`: compact strings and non-integral coordinates. Whole-number doubles such as `75.0` encode as `75` on Kotlin/JS, so `JsonPrimitive` string equality fails even though the values are the same.

## Test plan

- `mise exec -- ./gradlew :geojson:jsNodeTest --tests "*ExtraAxesTest*"`
- `mise exec -- ./gradlew :geojson:jvmTest --tests "*ExtraAxesTest*"`

## AI assistance

- **Tools:** Cursor
- **Models:** Cursor Grok 4.6
- **Context:** Follow-up to https://github.com/maplibre/spatial-k/pull/378 — extra-axis constructors existed but were untested. JS CI failures were caused by whole-number Double JSON encoding, not dropped axes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92e9fab0-4189-4d36-9272-02fab2b49917?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92e9fab0-4189-4d36-9272-02fab2b49917&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

