### PR TITLE
feat(geohash): add Geohash cells and OsmShortlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ module is a distinct library.
 ## Project map
 
 - `geojson` — GeoJSON types and DSL
+- `geohash` — Geohash cells and OpenStreetMap shortlinks
 - `turf` — geospatial analysis (port of Turf.js)
 - `units` — units of measure
 - `gpx` — GPX format support
@@ -18,6 +19,9 @@ module is a distinct library.
 ## Reference resources
 
 - GeoJSON: [RFC 7946](https://www.rfc-editor.org/rfc/rfc7946).
+- Geohash: [Geohash format](https://en.wikipedia.org/wiki/Geohash) and OpenStreetMap
+  [shortlink documentation](https://wiki.openstreetmap.org/wiki/Shortlink) and
+  [Rails implementation](https://github.com/openstreetmap/openstreetmap-website/blob/master/lib/short_link.rb).
 - Turf: [Turf.js docs](https://turfjs.org/docs/) and
   [source repository](https://github.com/Turfjs/turf).
 - Units: [BIPM SI Brochure](https://www.bipm.org/en/publications/si-brochure) and

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It includes:
 - GPX implementation
 - PMTiles v3 archive reader
 - Google Encoded Polyline Algorithm support
+- Geohash cells and OpenStreetMap shortlinks
 
 Spatial K supports Kotlin Multiplatform and Java projects.
 
@@ -35,6 +36,7 @@ dependencies {
     implementation("org.maplibre.spatialk:gpx:VERSION")
     implementation("org.maplibre.spatialk:pmtiles:VERSION")
     implementation("org.maplibre.spatialk:polyline-encoding:VERSION")
+    implementation("org.maplibre.spatialk:geohash:VERSION")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,9 @@ dependencies {
     dokka(project(":geojson"))
     kover(project(":geojson"))
 
+    dokka(project(":geohash"))
+    kover(project(":geohash"))
+
     dokka(project(":units"))
     kover(project(":units"))
 

--- a/docs/astro.config.mts
+++ b/docs/astro.config.mts
@@ -92,6 +92,7 @@ export default defineConfig({
           label: "Modules",
           items: [
             { label: "GeoJSON", link: "/geojson/" },
+            { label: "Geohash", link: "/geohash/" },
             { label: "Turf", link: "/turf/" },
             { label: "Units", link: "/units/" },
             { label: "GPX", link: "/gpx/" },

--- a/docs/src/content/docs/geohash/index.mdx
+++ b/docs/src/content/docs/geohash/index.mdx
@@ -4,11 +4,11 @@ title: "Geohash"
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-The `geohash` module represents
-[Geohash](https://en.wikipedia.org/wiki/Geohash) cells and
-[OpenStreetMap shortlinks](https://wiki.openstreetmap.org/wiki/Shortlink).
+A `Geohash` is a WGS84 cell. Length is stored on the value, so `ezs42` and `ezs420` are different
+cells. `OsmShortlink` is the OSM `/go/` encoding. Different alphabet, carries zoom, no parent or
+neighbors.
 
-Details can be found in the [API reference](/spatial-k/api/dokka/geohash/index.html).
+See the [API reference](/spatial-k/api/dokka/geohash/index.html).
 
 ## Installation
 
@@ -34,8 +34,8 @@ Details can be found in the [API reference](/spatial-k/api/dokka/geohash/index.h
 
 ## Encode a position
 
-`Geohash.of` returns the cell of a requested length that contains a WGS84 position.
-It ignores altitude.
+`Geohash.of` returns the cell of a given length that contains a longitude and latitude. Altitude
+does not change the cell.
 
 ```kotlin
 --8<-- "geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt:encode"
@@ -43,8 +43,8 @@ It ignores altitude.
 
 ## Parse and inspect a cell
 
-`Geohash.parse` accepts uppercase or lowercase base32ghs text and emits lowercase `text`.
-Each cell provides its center, bounding box, parent, and children.
+`Geohash.parse` folds ASCII case. `text` comes back lowercase. The cell also has `center`,
+`boundingBox`, `parent`, and `children`.
 
 ```kotlin
 --8<-- "geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt:parse"
@@ -52,9 +52,8 @@ Each cell provides its center, bounding box, parent, and children.
 
 ## Move between cells
 
-`neighbors` names the eight compass directions.
-Longitude wraps at the antimeridian, while directions past a pole are `null`.
-Use `offsetBy` for moves longer than one cell.
+`neighbors` is one property per compass direction. East and west always exist. A step past a pole is
+`null`. `offsetBy` moves more than one cell at a time.
 
 ```kotlin
 --8<-- "geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt:neighbors"
@@ -62,7 +61,8 @@ Use `offsetBy` for moves longer than one cell.
 
 ## Test containment
 
-A cell contains its own positions and descendant cells.
+`position in cell` is true when encoding that position at the same length yields the same cell. A
+longer hash whose prefix matches is inside too.
 
 ```kotlin
 --8<-- "geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt:containment"
@@ -70,17 +70,16 @@ A cell contains its own positions and descendant cells.
 
 ## Serialize as text
 
-`Geohash` and `OsmShortlink` serialize as their canonical strings.
+JSON for both types is the canonical string. `"ezs42"` or `"0EEQjE--"`, not an object.
 
 ```kotlin
 --8<-- "geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt:serialize"
 ```
 
-## Use OpenStreetMap shortlinks
+## OpenStreetMap shortlinks
 
-`OsmShortlink.parse` accepts a bare code, a `/go/` path, or an `osm.org` or
-`openstreetmap.org` URL. It accepts the historical `@` and `=` characters and emits the current
-`~` and `-` characters.
+`OsmShortlink.parse` takes a bare code, a `/go/` path, or an `osm.org` / `openstreetmap.org` URL.
+Old `@` and `=` still parse. `text` uses `~` and `-`.
 
 ```kotlin
 --8<-- "geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt:osmShortlink"

--- a/docs/src/content/docs/geohash/index.mdx
+++ b/docs/src/content/docs/geohash/index.mdx
@@ -1,0 +1,79 @@
+---
+title: "Geohash"
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+The `geohash` module represents
+[Geohash](https://en.wikipedia.org/wiki/Geohash) cells and
+[OpenStreetMap shortlinks](https://wiki.openstreetmap.org/wiki/Shortlink).
+
+Details can be found in the [API reference](/spatial-k/api/dokka/geohash/index.html).
+
+## Installation
+
+<Tabs syncKey="language">
+  <TabItem label="Multiplatform">
+    ```kotlin
+    commonMain {
+        dependencies {
+            implementation("org.maplibre.spatialk:geohash:{{ gradle.project_version }}")
+        }
+    }
+    ```
+  </TabItem>
+
+  <TabItem label="JVM">
+    ```kotlin
+    dependencies {
+        implementation("org.maplibre.spatialk:geohash-jvm:{{ gradle.project_version }}")
+    }
+    ```
+  </TabItem>
+</Tabs>
+
+## Encode a position
+
+`Geohash.of` returns the cell of a requested length that contains a WGS84 position.
+It ignores altitude.
+
+```kotlin
+--8<-- "geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt:encode"
+```
+
+## Parse and inspect a cell
+
+`Geohash.parse` accepts uppercase or lowercase base32ghs text and emits lowercase `text`.
+Each cell provides its center, bounding box, and parent.
+
+```kotlin
+--8<-- "geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt:parse"
+```
+
+## Move between cells
+
+`neighbors` names the eight compass directions.
+Longitude wraps at the antimeridian, while directions past a pole are `null`.
+Use `offsetBy` for moves longer than one cell.
+
+```kotlin
+--8<-- "geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt:neighbors"
+```
+
+## Test containment
+
+A cell contains its own positions and descendant cells.
+
+```kotlin
+--8<-- "geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt:containment"
+```
+
+## Use OpenStreetMap shortlinks
+
+`OsmShortlink.parse` accepts a bare code, a `/go/` path, or an `osm.org` or
+`openstreetmap.org` URL. It accepts the historical `@` and `=` characters and emits the current
+`~` and `-` characters.
+
+```kotlin
+--8<-- "geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt:osmShortlink"
+```

--- a/docs/src/content/docs/geohash/index.mdx
+++ b/docs/src/content/docs/geohash/index.mdx
@@ -44,7 +44,7 @@ It ignores altitude.
 ## Parse and inspect a cell
 
 `Geohash.parse` accepts uppercase or lowercase base32ghs text and emits lowercase `text`.
-Each cell provides its center, bounding box, and parent.
+Each cell provides its center, bounding box, parent, and children.
 
 ```kotlin
 --8<-- "geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt:parse"
@@ -66,6 +66,14 @@ A cell contains its own positions and descendant cells.
 
 ```kotlin
 --8<-- "geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt:containment"
+```
+
+## Serialize as text
+
+`Geohash` and `OsmShortlink` serialize as their canonical strings.
+
+```kotlin
+--8<-- "geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt:serialize"
 ```
 
 ## Use OpenStreetMap shortlinks

--- a/docs/src/content/docs/geohash/index.mdx
+++ b/docs/src/content/docs/geohash/index.mdx
@@ -4,9 +4,11 @@ title: "Geohash"
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-A `Geohash` is a WGS84 cell. Length is stored on the value, so `ezs42` and `ezs420` are different
-cells. `OsmShortlink` is the OSM `/go/` encoding. Different alphabet, carries zoom, no parent or
-neighbors.
+A `Geohash` is a [WGS84](https://en.wikipedia.org/wiki/World_Geodetic_System#WGS_84) cell in the
+[Geohash](https://en.wikipedia.org/wiki/Geohash) grid. Length is stored on the value, so `ezs42` and
+`ezs420` are different cells. `OsmShortlink` is the
+[OpenStreetMap shortlink](https://wiki.openstreetmap.org/wiki/Shortlink) `/go/` encoding. Different
+alphabet, carries zoom, no parent or neighbors.
 
 See the [API reference](/spatial-k/api/dokka/geohash/index.html).
 

--- a/geohash/MODULE.md
+++ b/geohash/MODULE.md
@@ -14,6 +14,7 @@ val cell =
 cell.text // "u4pruydqqvj"
 cell.center
 cell.boundingBox
+cell.children
 cell.neighbors.east
 ```
 

--- a/geohash/MODULE.md
+++ b/geohash/MODULE.md
@@ -1,0 +1,24 @@
+# Module geohash
+
+Geohash cells and OpenStreetMap shortlinks.
+
+Create a Geohash cell from a WGS84 position:
+
+```kotlin
+val cell =
+    Geohash.of(
+        Position(longitude = 10.40744, latitude = 57.64911),
+        length = 11,
+    )
+
+cell.text // "u4pruydqqvj"
+cell.center
+cell.boundingBox
+cell.neighbors.east
+```
+
+Parse an OpenStreetMap shortlink from a code, a `/go/` path, or a URL:
+
+```kotlin
+val shortlink = OsmShortlink.parse("https://osm.org/go/0EEQjE--")
+```

--- a/geohash/api/geohash.api
+++ b/geohash/api/geohash.api
@@ -8,6 +8,7 @@ public final class org/maplibre/spatialk/geohash/Geohash : java/lang/Comparable 
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBoundingBox ()Lorg/maplibre/spatialk/geojson/BoundingBox;
 	public final fun getCenter ()Lorg/maplibre/spatialk/geojson/Position;
+	public final fun getChildren ()Ljava/util/List;
 	public final fun getLength ()I
 	public final fun getNeighbors ()Lorg/maplibre/spatialk/geohash/GeohashNeighbors;
 	public final fun getParent ()Lorg/maplibre/spatialk/geohash/Geohash;
@@ -25,6 +26,7 @@ public final class org/maplibre/spatialk/geohash/Geohash$Companion {
 	public final fun of (Lorg/maplibre/spatialk/geojson/Position;I)Lorg/maplibre/spatialk/geohash/Geohash;
 	public final fun parse (Ljava/lang/String;)Lorg/maplibre/spatialk/geohash/Geohash;
 	public final fun parseOrNull (Ljava/lang/String;)Lorg/maplibre/spatialk/geohash/Geohash;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class org/maplibre/spatialk/geohash/GeohashNeighbors {
@@ -58,5 +60,6 @@ public final class org/maplibre/spatialk/geohash/OsmShortlink$Companion {
 	public final fun of (Lorg/maplibre/spatialk/geojson/Position;I)Lorg/maplibre/spatialk/geohash/OsmShortlink;
 	public final fun parse (Ljava/lang/String;)Lorg/maplibre/spatialk/geohash/OsmShortlink;
 	public final fun parseOrNull (Ljava/lang/String;)Lorg/maplibre/spatialk/geohash/OsmShortlink;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/geohash/api/geohash.api
+++ b/geohash/api/geohash.api
@@ -1,0 +1,62 @@
+public final class org/maplibre/spatialk/geohash/Geohash : java/lang/Comparable {
+	public static final field Companion Lorg/maplibre/spatialk/geohash/Geohash$Companion;
+	public static final field MaxLength I
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun compareTo (Lorg/maplibre/spatialk/geohash/Geohash;)I
+	public final fun contains (Lorg/maplibre/spatialk/geohash/Geohash;)Z
+	public final fun contains (Lorg/maplibre/spatialk/geojson/Position;)Z
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoundingBox ()Lorg/maplibre/spatialk/geojson/BoundingBox;
+	public final fun getCenter ()Lorg/maplibre/spatialk/geojson/Position;
+	public final fun getLength ()I
+	public final fun getNeighbors ()Lorg/maplibre/spatialk/geohash/GeohashNeighbors;
+	public final fun getParent ()Lorg/maplibre/spatialk/geohash/Geohash;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static final fun of (Lorg/maplibre/spatialk/geojson/Position;I)Lorg/maplibre/spatialk/geohash/Geohash;
+	public final fun offsetBy (II)Lorg/maplibre/spatialk/geohash/Geohash;
+	public static final fun parse (Ljava/lang/String;)Lorg/maplibre/spatialk/geohash/Geohash;
+	public static final fun parseOrNull (Ljava/lang/String;)Lorg/maplibre/spatialk/geohash/Geohash;
+	public fun toString ()Ljava/lang/String;
+	public final fun truncatedTo (I)Lorg/maplibre/spatialk/geohash/Geohash;
+}
+
+public final class org/maplibre/spatialk/geohash/Geohash$Companion {
+	public final fun of (Lorg/maplibre/spatialk/geojson/Position;I)Lorg/maplibre/spatialk/geohash/Geohash;
+	public final fun parse (Ljava/lang/String;)Lorg/maplibre/spatialk/geohash/Geohash;
+	public final fun parseOrNull (Ljava/lang/String;)Lorg/maplibre/spatialk/geohash/Geohash;
+}
+
+public final class org/maplibre/spatialk/geohash/GeohashNeighbors {
+	public final fun getEast ()Lorg/maplibre/spatialk/geohash/Geohash;
+	public final fun getNorth ()Lorg/maplibre/spatialk/geohash/Geohash;
+	public final fun getNorthEast ()Lorg/maplibre/spatialk/geohash/Geohash;
+	public final fun getNorthWest ()Lorg/maplibre/spatialk/geohash/Geohash;
+	public final fun getSouth ()Lorg/maplibre/spatialk/geohash/Geohash;
+	public final fun getSouthEast ()Lorg/maplibre/spatialk/geohash/Geohash;
+	public final fun getSouthWest ()Lorg/maplibre/spatialk/geohash/Geohash;
+	public final fun getWest ()Lorg/maplibre/spatialk/geohash/Geohash;
+	public final fun toList ()Ljava/util/List;
+}
+
+public final class org/maplibre/spatialk/geohash/OsmShortlink {
+	public static final field Companion Lorg/maplibre/spatialk/geohash/OsmShortlink$Companion;
+	public static final field MaxZoom I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoundingBox ()Lorg/maplibre/spatialk/geojson/BoundingBox;
+	public final fun getCenter ()Lorg/maplibre/spatialk/geojson/Position;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getZoom ()I
+	public fun hashCode ()I
+	public static final fun of (Lorg/maplibre/spatialk/geojson/Position;I)Lorg/maplibre/spatialk/geohash/OsmShortlink;
+	public static final fun parse (Ljava/lang/String;)Lorg/maplibre/spatialk/geohash/OsmShortlink;
+	public static final fun parseOrNull (Ljava/lang/String;)Lorg/maplibre/spatialk/geohash/OsmShortlink;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/maplibre/spatialk/geohash/OsmShortlink$Companion {
+	public final fun of (Lorg/maplibre/spatialk/geojson/Position;I)Lorg/maplibre/spatialk/geohash/OsmShortlink;
+	public final fun parse (Ljava/lang/String;)Lorg/maplibre/spatialk/geohash/OsmShortlink;
+	public final fun parseOrNull (Ljava/lang/String;)Lorg/maplibre/spatialk/geohash/OsmShortlink;
+}
+

--- a/geohash/api/geohash.klib.api
+++ b/geohash/api/geohash.klib.api
@@ -1,0 +1,85 @@
+// Klib ABI Dump
+// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, mingwX64, tvosArm64, tvosSimulatorArm64, wasmJs, wasmWasi, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <org.maplibre.spatialk:geohash>
+final class org.maplibre.spatialk.geohash/Geohash : kotlin/Comparable<org.maplibre.spatialk.geohash/Geohash> { // org.maplibre.spatialk.geohash/Geohash|null[0]
+    final val boundingBox // org.maplibre.spatialk.geohash/Geohash.boundingBox|{}boundingBox[0]
+        final fun <get-boundingBox>(): org.maplibre.spatialk.geojson/BoundingBox // org.maplibre.spatialk.geohash/Geohash.boundingBox.<get-boundingBox>|<get-boundingBox>(){}[0]
+    final val center // org.maplibre.spatialk.geohash/Geohash.center|{}center[0]
+        final fun <get-center>(): org.maplibre.spatialk.geojson/Position // org.maplibre.spatialk.geohash/Geohash.center.<get-center>|<get-center>(){}[0]
+    final val length // org.maplibre.spatialk.geohash/Geohash.length|{}length[0]
+        final fun <get-length>(): kotlin/Int // org.maplibre.spatialk.geohash/Geohash.length.<get-length>|<get-length>(){}[0]
+    final val neighbors // org.maplibre.spatialk.geohash/Geohash.neighbors|{}neighbors[0]
+        final fun <get-neighbors>(): org.maplibre.spatialk.geohash/GeohashNeighbors // org.maplibre.spatialk.geohash/Geohash.neighbors.<get-neighbors>|<get-neighbors>(){}[0]
+    final val parent // org.maplibre.spatialk.geohash/Geohash.parent|{}parent[0]
+        final fun <get-parent>(): org.maplibre.spatialk.geohash/Geohash? // org.maplibre.spatialk.geohash/Geohash.parent.<get-parent>|<get-parent>(){}[0]
+    final val text // org.maplibre.spatialk.geohash/Geohash.text|{}text[0]
+        final fun <get-text>(): kotlin/String // org.maplibre.spatialk.geohash/Geohash.text.<get-text>|<get-text>(){}[0]
+
+    final fun compareTo(org.maplibre.spatialk.geohash/Geohash): kotlin/Int // org.maplibre.spatialk.geohash/Geohash.compareTo|compareTo(org.maplibre.spatialk.geohash.Geohash){}[0]
+    final fun contains(org.maplibre.spatialk.geohash/Geohash): kotlin/Boolean // org.maplibre.spatialk.geohash/Geohash.contains|contains(org.maplibre.spatialk.geohash.Geohash){}[0]
+    final fun contains(org.maplibre.spatialk.geojson/Position): kotlin/Boolean // org.maplibre.spatialk.geohash/Geohash.contains|contains(org.maplibre.spatialk.geojson.Position){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // org.maplibre.spatialk.geohash/Geohash.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // org.maplibre.spatialk.geohash/Geohash.hashCode|hashCode(){}[0]
+    final fun offsetBy(kotlin/Int, kotlin/Int): org.maplibre.spatialk.geohash/Geohash? // org.maplibre.spatialk.geohash/Geohash.offsetBy|offsetBy(kotlin.Int;kotlin.Int){}[0]
+    final fun toString(): kotlin/String // org.maplibre.spatialk.geohash/Geohash.toString|toString(){}[0]
+    final fun truncatedTo(kotlin/Int): org.maplibre.spatialk.geohash/Geohash // org.maplibre.spatialk.geohash/Geohash.truncatedTo|truncatedTo(kotlin.Int){}[0]
+
+    final object Companion { // org.maplibre.spatialk.geohash/Geohash.Companion|null[0]
+        final const val MaxLength // org.maplibre.spatialk.geohash/Geohash.Companion.MaxLength|{}MaxLength[0]
+            final fun <get-MaxLength>(): kotlin/Int // org.maplibre.spatialk.geohash/Geohash.Companion.MaxLength.<get-MaxLength>|<get-MaxLength>(){}[0]
+
+        final fun of(org.maplibre.spatialk.geojson/Position, kotlin/Int): org.maplibre.spatialk.geohash/Geohash // org.maplibre.spatialk.geohash/Geohash.Companion.of|of(org.maplibre.spatialk.geojson.Position;kotlin.Int){}[0]
+        final fun parse(kotlin/String): org.maplibre.spatialk.geohash/Geohash // org.maplibre.spatialk.geohash/Geohash.Companion.parse|parse(kotlin.String){}[0]
+        final fun parseOrNull(kotlin/String): org.maplibre.spatialk.geohash/Geohash? // org.maplibre.spatialk.geohash/Geohash.Companion.parseOrNull|parseOrNull(kotlin.String){}[0]
+    }
+}
+
+final class org.maplibre.spatialk.geohash/GeohashNeighbors { // org.maplibre.spatialk.geohash/GeohashNeighbors|null[0]
+    final val east // org.maplibre.spatialk.geohash/GeohashNeighbors.east|{}east[0]
+        final fun <get-east>(): org.maplibre.spatialk.geohash/Geohash // org.maplibre.spatialk.geohash/GeohashNeighbors.east.<get-east>|<get-east>(){}[0]
+    final val north // org.maplibre.spatialk.geohash/GeohashNeighbors.north|{}north[0]
+        final fun <get-north>(): org.maplibre.spatialk.geohash/Geohash? // org.maplibre.spatialk.geohash/GeohashNeighbors.north.<get-north>|<get-north>(){}[0]
+    final val northEast // org.maplibre.spatialk.geohash/GeohashNeighbors.northEast|{}northEast[0]
+        final fun <get-northEast>(): org.maplibre.spatialk.geohash/Geohash? // org.maplibre.spatialk.geohash/GeohashNeighbors.northEast.<get-northEast>|<get-northEast>(){}[0]
+    final val northWest // org.maplibre.spatialk.geohash/GeohashNeighbors.northWest|{}northWest[0]
+        final fun <get-northWest>(): org.maplibre.spatialk.geohash/Geohash? // org.maplibre.spatialk.geohash/GeohashNeighbors.northWest.<get-northWest>|<get-northWest>(){}[0]
+    final val south // org.maplibre.spatialk.geohash/GeohashNeighbors.south|{}south[0]
+        final fun <get-south>(): org.maplibre.spatialk.geohash/Geohash? // org.maplibre.spatialk.geohash/GeohashNeighbors.south.<get-south>|<get-south>(){}[0]
+    final val southEast // org.maplibre.spatialk.geohash/GeohashNeighbors.southEast|{}southEast[0]
+        final fun <get-southEast>(): org.maplibre.spatialk.geohash/Geohash? // org.maplibre.spatialk.geohash/GeohashNeighbors.southEast.<get-southEast>|<get-southEast>(){}[0]
+    final val southWest // org.maplibre.spatialk.geohash/GeohashNeighbors.southWest|{}southWest[0]
+        final fun <get-southWest>(): org.maplibre.spatialk.geohash/Geohash? // org.maplibre.spatialk.geohash/GeohashNeighbors.southWest.<get-southWest>|<get-southWest>(){}[0]
+    final val west // org.maplibre.spatialk.geohash/GeohashNeighbors.west|{}west[0]
+        final fun <get-west>(): org.maplibre.spatialk.geohash/Geohash // org.maplibre.spatialk.geohash/GeohashNeighbors.west.<get-west>|<get-west>(){}[0]
+
+    final fun toList(): kotlin.collections/List<org.maplibre.spatialk.geohash/Geohash> // org.maplibre.spatialk.geohash/GeohashNeighbors.toList|toList(){}[0]
+}
+
+final class org.maplibre.spatialk.geohash/OsmShortlink { // org.maplibre.spatialk.geohash/OsmShortlink|null[0]
+    final val boundingBox // org.maplibre.spatialk.geohash/OsmShortlink.boundingBox|{}boundingBox[0]
+        final fun <get-boundingBox>(): org.maplibre.spatialk.geojson/BoundingBox // org.maplibre.spatialk.geohash/OsmShortlink.boundingBox.<get-boundingBox>|<get-boundingBox>(){}[0]
+    final val center // org.maplibre.spatialk.geohash/OsmShortlink.center|{}center[0]
+        final fun <get-center>(): org.maplibre.spatialk.geojson/Position // org.maplibre.spatialk.geohash/OsmShortlink.center.<get-center>|<get-center>(){}[0]
+    final val text // org.maplibre.spatialk.geohash/OsmShortlink.text|{}text[0]
+        final fun <get-text>(): kotlin/String // org.maplibre.spatialk.geohash/OsmShortlink.text.<get-text>|<get-text>(){}[0]
+    final val zoom // org.maplibre.spatialk.geohash/OsmShortlink.zoom|{}zoom[0]
+        final fun <get-zoom>(): kotlin/Int // org.maplibre.spatialk.geohash/OsmShortlink.zoom.<get-zoom>|<get-zoom>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // org.maplibre.spatialk.geohash/OsmShortlink.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // org.maplibre.spatialk.geohash/OsmShortlink.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // org.maplibre.spatialk.geohash/OsmShortlink.toString|toString(){}[0]
+
+    final object Companion { // org.maplibre.spatialk.geohash/OsmShortlink.Companion|null[0]
+        final const val MaxZoom // org.maplibre.spatialk.geohash/OsmShortlink.Companion.MaxZoom|{}MaxZoom[0]
+            final fun <get-MaxZoom>(): kotlin/Int // org.maplibre.spatialk.geohash/OsmShortlink.Companion.MaxZoom.<get-MaxZoom>|<get-MaxZoom>(){}[0]
+
+        final fun of(org.maplibre.spatialk.geojson/Position, kotlin/Int): org.maplibre.spatialk.geohash/OsmShortlink // org.maplibre.spatialk.geohash/OsmShortlink.Companion.of|of(org.maplibre.spatialk.geojson.Position;kotlin.Int){}[0]
+        final fun parse(kotlin/String): org.maplibre.spatialk.geohash/OsmShortlink // org.maplibre.spatialk.geohash/OsmShortlink.Companion.parse|parse(kotlin.String){}[0]
+        final fun parseOrNull(kotlin/String): org.maplibre.spatialk.geohash/OsmShortlink? // org.maplibre.spatialk.geohash/OsmShortlink.Companion.parseOrNull|parseOrNull(kotlin.String){}[0]
+    }
+}

--- a/geohash/api/geohash.klib.api
+++ b/geohash/api/geohash.klib.api
@@ -11,6 +11,8 @@ final class org.maplibre.spatialk.geohash/Geohash : kotlin/Comparable<org.maplib
         final fun <get-boundingBox>(): org.maplibre.spatialk.geojson/BoundingBox // org.maplibre.spatialk.geohash/Geohash.boundingBox.<get-boundingBox>|<get-boundingBox>(){}[0]
     final val center // org.maplibre.spatialk.geohash/Geohash.center|{}center[0]
         final fun <get-center>(): org.maplibre.spatialk.geojson/Position // org.maplibre.spatialk.geohash/Geohash.center.<get-center>|<get-center>(){}[0]
+    final val children // org.maplibre.spatialk.geohash/Geohash.children|{}children[0]
+        final fun <get-children>(): kotlin.collections/List<org.maplibre.spatialk.geohash/Geohash> // org.maplibre.spatialk.geohash/Geohash.children.<get-children>|<get-children>(){}[0]
     final val length // org.maplibre.spatialk.geohash/Geohash.length|{}length[0]
         final fun <get-length>(): kotlin/Int // org.maplibre.spatialk.geohash/Geohash.length.<get-length>|<get-length>(){}[0]
     final val neighbors // org.maplibre.spatialk.geohash/Geohash.neighbors|{}neighbors[0]
@@ -36,6 +38,7 @@ final class org.maplibre.spatialk.geohash/Geohash : kotlin/Comparable<org.maplib
         final fun of(org.maplibre.spatialk.geojson/Position, kotlin/Int): org.maplibre.spatialk.geohash/Geohash // org.maplibre.spatialk.geohash/Geohash.Companion.of|of(org.maplibre.spatialk.geojson.Position;kotlin.Int){}[0]
         final fun parse(kotlin/String): org.maplibre.spatialk.geohash/Geohash // org.maplibre.spatialk.geohash/Geohash.Companion.parse|parse(kotlin.String){}[0]
         final fun parseOrNull(kotlin/String): org.maplibre.spatialk.geohash/Geohash? // org.maplibre.spatialk.geohash/Geohash.Companion.parseOrNull|parseOrNull(kotlin.String){}[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<org.maplibre.spatialk.geohash/Geohash> // org.maplibre.spatialk.geohash/Geohash.Companion.serializer|serializer(){}[0]
     }
 }
 
@@ -81,5 +84,6 @@ final class org.maplibre.spatialk.geohash/OsmShortlink { // org.maplibre.spatial
         final fun of(org.maplibre.spatialk.geojson/Position, kotlin/Int): org.maplibre.spatialk.geohash/OsmShortlink // org.maplibre.spatialk.geohash/OsmShortlink.Companion.of|of(org.maplibre.spatialk.geojson.Position;kotlin.Int){}[0]
         final fun parse(kotlin/String): org.maplibre.spatialk.geohash/OsmShortlink // org.maplibre.spatialk.geohash/OsmShortlink.Companion.parse|parse(kotlin.String){}[0]
         final fun parseOrNull(kotlin/String): org.maplibre.spatialk.geohash/OsmShortlink? // org.maplibre.spatialk.geohash/OsmShortlink.Companion.parseOrNull|parseOrNull(kotlin.String){}[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<org.maplibre.spatialk.geohash/OsmShortlink> // org.maplibre.spatialk.geohash/OsmShortlink.Companion.serializer|serializer(){}[0]
     }
 }

--- a/geohash/build.gradle.kts
+++ b/geohash/build.gradle.kts
@@ -2,9 +2,15 @@ plugins { id("published-library") }
 
 kotlin {
     sourceSets {
-        commonMain.dependencies { api(project(":geojson")) }
+        commonMain.dependencies {
+            api(project(":geojson"))
+            implementation(libs.kotlinx.serialization.core)
+        }
 
-        commonTest.dependencies { implementation(project(":testutil")) }
+        commonTest.dependencies {
+            implementation(project(":testutil"))
+            implementation(libs.kotlinx.serialization.json)
+        }
 
         jvmTest.dependencies { implementation(kotlin("test")) }
     }

--- a/geohash/build.gradle.kts
+++ b/geohash/build.gradle.kts
@@ -1,4 +1,7 @@
-plugins { id("published-library") }
+plugins {
+    id("published-library")
+    id("test-resources")
+}
 
 kotlin {
     sourceSets {

--- a/geohash/build.gradle.kts
+++ b/geohash/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins { id("published-library") }
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies { api(project(":geojson")) }
+
+        commonTest.dependencies { implementation(project(":testutil")) }
+
+        jvmTest.dependencies { implementation(kotlin("test")) }
+    }
+}
+
+mavenPublishing {
+    pom {
+        name = "Spatial K Geohash"
+        description =
+            "A Kotlin Multiplatform library for Geohash cells and OpenStreetMap shortlinks."
+    }
+}

--- a/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/Geohash.kt
+++ b/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/Geohash.kt
@@ -121,6 +121,7 @@ public class Geohash private constructor(private val packed: Long) : Comparable<
      *
      * @throws IllegalArgumentException if [length] is outside `1..this.length`.
      */
+    @Throws(IllegalArgumentException::class)
     public fun truncatedTo(length: Int): Geohash {
         require(length in 1..this.length) {
             "Target length must be in 1..${this.length}, but was $length"
@@ -134,6 +135,7 @@ public class Geohash private constructor(private val packed: Long) : Comparable<
      *
      * Altitude is ignored. Invalid coordinates throw as they do in [of].
      */
+    @Throws(IllegalArgumentException::class)
     public operator fun contains(position: Position): Boolean = of(position, length) == this
 
     /** Returns true when [other] is this cell or one of its descendants. */

--- a/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/Geohash.kt
+++ b/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/Geohash.kt
@@ -13,8 +13,8 @@ import org.maplibre.spatialk.geojson.Position
  * A rectangular cell on the WGS84 longitude and latitude plane, addressed by a
  * [Geohash](https://en.wikipedia.org/wiki/Geohash) string.
  *
- * A `Geohash` is a cell rather than a string codec. Its [text], [center], and [boundingBox] are
- * projections of one packed value. Altitude is ignored.
+ * A `Geohash` is a cell rather than a string codec. Its [text], [center], [boundingBox], [parent],
+ * and [neighbors] are projections of one packed value. Altitude is ignored.
  *
  * Every instance is valid. Construction validates untrusted coordinates or text once, then cell
  * operations trust the instance.
@@ -26,13 +26,15 @@ public class Geohash private constructor(private val packed: Long) : Comparable<
 
     /** This cell's lowercase base32ghs address. */
     public val text: String
-        get() =
-            buildString(length) {
-                repeat(length) { index ->
+        get() {
+            val characterCount = length
+            return buildString(characterCount) {
+                repeat(characterCount) { index ->
                     val shift = 64 - BitsPerCharacter * (index + 1)
                     append(BASE32_GHS[((packed ushr shift) and CharacterMask).toInt()])
                 }
             }
+        }
 
     /**
      * The geometric center of this cell.
@@ -70,6 +72,77 @@ public class Geohash private constructor(private val packed: Long) : Comparable<
                 north = south + latitudeStep,
             )
         }
+
+    /** The enclosing cell one character shorter, or `null` when [length] is `1`. */
+    public val parent: Geohash?
+        get() = if (length == 1) null else truncatedTo(length - 1)
+
+    /**
+     * The adjacent cells at this [length], with named compass directions.
+     *
+     * Longitude wraps at the antimeridian. North-facing or south-facing entries are `null` when
+     * this cell touches the corresponding pole.
+     */
+    public val neighbors: GeohashNeighbors
+        get() =
+            GeohashNeighbors(
+                north = offsetBy(east = 0, north = 1),
+                northEast = offsetBy(east = 1, north = 1),
+                east = offsetBy(east = 1, north = 0)!!,
+                southEast = offsetBy(east = 1, north = -1),
+                south = offsetBy(east = 0, north = -1),
+                southWest = offsetBy(east = -1, north = -1),
+                west = offsetBy(east = -1, north = 0)!!,
+                northWest = offsetBy(east = -1, north = 1),
+            )
+
+    /**
+     * Returns the cell reached by moving [east] cells east and [north] cells north.
+     *
+     * Longitude wraps at the antimeridian. Latitude does not wrap, so a move past either pole
+     * returns `null`.
+     */
+    public fun offsetBy(east: Int, north: Int): Geohash? {
+        val longitudeBits = longitudeBits(length)
+        val latitudeBits = latitudeBits(length)
+        val longitudeCells = 1L shl longitudeBits
+        val latitudeCells = 1L shl latitudeBits
+        val currentX = deinterleaveX(packed, longitudeBits, latitudeBits)
+        val currentY = deinterleaveY(packed, longitudeBits, latitudeBits)
+        val unwrappedX = (currentX.toLong() + east.toLong()) % longitudeCells
+        val x = if (unwrappedX < 0) unwrappedX + longitudeCells else unwrappedX
+        val y = currentY.toLong() + north.toLong()
+        if (y !in 0..<latitudeCells) return null
+
+        val morton = interleave(x.toInt(), longitudeBits, y.toInt(), latitudeBits)
+        return Geohash(morton or length.toLong())
+    }
+
+    /**
+     * Returns the enclosing cell whose address has [length] characters.
+     *
+     * Returns this cell when [length] equals this cell's length.
+     *
+     * @throws IllegalArgumentException if [length] is outside `1..this.length`.
+     */
+    public fun truncatedTo(length: Int): Geohash {
+        require(length in 1..this.length) {
+            "Target length must be in 1..${this.length}, but was $length"
+        }
+        val payloadMask = -1L shl (64 - BitsPerCharacter * length)
+        return Geohash((packed and payloadMask) or length.toLong())
+    }
+
+    /**
+     * Returns true when [position] falls inside this cell.
+     *
+     * Altitude is ignored. Invalid coordinates throw as they do in [of].
+     */
+    public operator fun contains(position: Position): Boolean = of(position, length) == this
+
+    /** Returns true when [other] is this cell or one of its descendants. */
+    public operator fun contains(other: Geohash): Boolean =
+        other.length >= length && other.truncatedTo(length) == this
 
     /**
      * Orders cells in the same order as their [text] forms.
@@ -187,4 +260,37 @@ public class Geohash private constructor(private val packed: Long) : Comparable<
 
         private fun latitudeBits(length: Int): Int = BitsPerCharacter * length / 2
     }
+}
+
+/**
+ * The eight cells adjacent to a [Geohash], one property per compass direction.
+ *
+ * Longitude wraps, so [east] and [west] always exist. Properties that cross a pole are `null`.
+ */
+public class GeohashNeighbors
+internal constructor(
+    /** The adjacent cell to the north, or `null` at the north pole. */
+    public val north: Geohash?,
+    /** The adjacent cell to the northeast, or `null` at the north pole. */
+    public val northEast: Geohash?,
+    /** The adjacent cell to the east. */
+    public val east: Geohash,
+    /** The adjacent cell to the southeast, or `null` at the south pole. */
+    public val southEast: Geohash?,
+    /** The adjacent cell to the south, or `null` at the south pole. */
+    public val south: Geohash?,
+    /** The adjacent cell to the southwest, or `null` at the south pole. */
+    public val southWest: Geohash?,
+    /** The adjacent cell to the west. */
+    public val west: Geohash,
+    /** The adjacent cell to the northwest, or `null` at the north pole. */
+    public val northWest: Geohash?,
+) {
+    /**
+     * Returns existing neighbors in N, NE, E, SE, S, SW, W, NW order.
+     *
+     * Directions that cross a pole are omitted.
+     */
+    public fun toList(): List<Geohash> =
+        listOfNotNull(north, northEast, east, southEast, south, southWest, west, northWest)
 }

--- a/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/Geohash.kt
+++ b/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/Geohash.kt
@@ -1,0 +1,190 @@
+package org.maplibre.spatialk.geohash
+
+import kotlin.jvm.JvmStatic
+import org.maplibre.spatialk.geohash.internal.BASE32_GHS
+import org.maplibre.spatialk.geohash.internal.base32GhsValue
+import org.maplibre.spatialk.geohash.internal.deinterleaveX
+import org.maplibre.spatialk.geohash.internal.deinterleaveY
+import org.maplibre.spatialk.geohash.internal.interleave
+import org.maplibre.spatialk.geojson.BoundingBox
+import org.maplibre.spatialk.geojson.Position
+
+/**
+ * A rectangular cell on the WGS84 longitude and latitude plane, addressed by a
+ * [Geohash](https://en.wikipedia.org/wiki/Geohash) string.
+ *
+ * A `Geohash` is a cell rather than a string codec. Its [text], [center], and [boundingBox] are
+ * projections of one packed value. Altitude is ignored.
+ *
+ * Every instance is valid. Construction validates untrusted coordinates or text once, then cell
+ * operations trust the instance.
+ */
+public class Geohash private constructor(private val packed: Long) : Comparable<Geohash> {
+    /** Number of base32ghs characters in this cell's address. */
+    public val length: Int
+        get() = (packed and LengthMask).toInt()
+
+    /** This cell's lowercase base32ghs address. */
+    public val text: String
+        get() =
+            buildString(length) {
+                repeat(length) { index ->
+                    val shift = 64 - BitsPerCharacter * (index + 1)
+                    append(BASE32_GHS[((packed ushr shift) and CharacterMask).toInt()])
+                }
+            }
+
+    /**
+     * The geometric center of this cell.
+     *
+     * Encoding the result at this cell's [length] returns an equal cell.
+     */
+    public val center: Position
+        get() {
+            val box = boundingBox
+            return Position(
+                longitude = (box.west + box.east) / 2.0,
+                latitude = (box.south + box.north) / 2.0,
+            )
+        }
+
+    /**
+     * The cell's two-dimensional extent in west, south, east, north order.
+     *
+     * The east and north edges are exclusive except at longitude `180` and latitude `90`.
+     */
+    public val boundingBox: BoundingBox
+        get() {
+            val longitudeBits = longitudeBits(length)
+            val latitudeBits = latitudeBits(length)
+            val x = deinterleaveX(packed, longitudeBits, latitudeBits)
+            val y = deinterleaveY(packed, longitudeBits, latitudeBits)
+            val longitudeStep = LongitudeSpan / (1L shl longitudeBits)
+            val latitudeStep = LatitudeSpan / (1L shl latitudeBits)
+            val west = MinimumLongitude + x * longitudeStep
+            val south = MinimumLatitude + y * latitudeStep
+            return BoundingBox(
+                west = west,
+                south = south,
+                east = west + longitudeStep,
+                north = south + latitudeStep,
+            )
+        }
+
+    /**
+     * Orders cells in the same order as their [text] forms.
+     *
+     * A parent address sorts before each of its descendants.
+     */
+    override fun compareTo(other: Geohash): Int = packed.toULong().compareTo(other.packed.toULong())
+
+    /** Returns true when [other] identifies the same cell. */
+    override fun equals(other: Any?): Boolean = other is Geohash && packed == other.packed
+
+    /** Returns a hash code consistent with [equals]. */
+    override fun hashCode(): Int = packed.hashCode()
+
+    /** Returns [text]. */
+    override fun toString(): String = text
+
+    /** Factories for valid [Geohash] cells. */
+    public companion object {
+        /** The longest supported address, `12` characters. */
+        public const val MaxLength: Int = 12
+
+        private const val BitsPerCharacter: Int = 5
+        private const val LengthMask: Long = 0xF
+        private const val CharacterMask: Long = 0x1F
+        private const val MinimumLongitude: Double = -180.0
+        private const val MaximumLongitude: Double = 180.0
+        private const val MinimumLatitude: Double = -90.0
+        private const val MaximumLatitude: Double = 90.0
+        private const val LongitudeSpan: Double = 360.0
+        private const val LatitudeSpan: Double = 180.0
+
+        /**
+         * Returns the cell of the given [length] that contains [position].
+         *
+         * Longitude must be in `-180.0..180.0`, latitude must be in `-90.0..90.0`, and both values
+         * must be finite. Altitude is ignored.
+         *
+         * @throws IllegalArgumentException if the length or coordinate is invalid.
+         */
+        @JvmStatic
+        @Throws(IllegalArgumentException::class)
+        public fun of(position: Position, length: Int): Geohash {
+            require(length in 1..MaxLength) {
+                "Geohash length must be in 1..$MaxLength, but was $length"
+            }
+            require(
+                position.longitude.isFinite() &&
+                    position.longitude in MinimumLongitude..MaximumLongitude
+            ) {
+                "Longitude must be finite and in $MinimumLongitude..$MaximumLongitude, but was ${position.longitude}"
+            }
+            require(
+                position.latitude.isFinite() &&
+                    position.latitude in MinimumLatitude..MaximumLatitude
+            ) {
+                "Latitude must be finite and in $MinimumLatitude..$MaximumLatitude, but was ${position.latitude}"
+            }
+
+            val longitudeBits = longitudeBits(length)
+            val latitudeBits = latitudeBits(length)
+            val longitudeCells = 1 shl longitudeBits
+            val latitudeCells = 1 shl latitudeBits
+            val x =
+                (((position.longitude - MinimumLongitude) / LongitudeSpan) * longitudeCells)
+                    .toInt()
+                    .coerceAtMost(longitudeCells - 1)
+            val y =
+                (((position.latitude - MinimumLatitude) / LatitudeSpan) * latitudeCells)
+                    .toInt()
+                    .coerceAtMost(latitudeCells - 1)
+            val morton = interleave(x, longitudeBits, y, latitudeBits)
+            return Geohash(morton or length.toLong())
+        }
+
+        /**
+         * Parses a base32ghs address after folding ASCII letters to lowercase.
+         *
+         * The address must contain `1..`[MaxLength] characters from
+         * `0123456789bcdefghjkmnpqrstuvwxyz`. For every accepted input, `parse(input).text ==
+         * input.lowercase()`.
+         *
+         * @throws IllegalArgumentException if [text] has an invalid length or character.
+         */
+        @JvmStatic
+        @Throws(IllegalArgumentException::class)
+        public fun parse(text: String): Geohash {
+            require(text.length in 1..MaxLength) {
+                "Geohash text length must be in 1..$MaxLength, but was ${text.length}"
+            }
+
+            var bits = 0L
+            text.forEachIndexed { index, char ->
+                val folded = if (char in 'A'..'Z') char + ('a' - 'A') else char
+                val value = base32GhsValue(folded)
+                require(value >= 0) {
+                    "Invalid geohash character '$char' at index $index"
+                }
+                bits = (bits shl BitsPerCharacter) or value.toLong()
+            }
+
+            return Geohash((bits shl (64 - BitsPerCharacter * text.length)) or text.length.toLong())
+        }
+
+        /** Parses a base32ghs address, or returns `null` when [text] is invalid. */
+        @JvmStatic
+        public fun parseOrNull(text: String): Geohash? =
+            try {
+                parse(text)
+            } catch (_: IllegalArgumentException) {
+                null
+            }
+
+        private fun longitudeBits(length: Int): Int = (BitsPerCharacter * length + 1) / 2
+
+        private fun latitudeBits(length: Int): Int = BitsPerCharacter * length / 2
+    }
+}

--- a/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/Geohash.kt
+++ b/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/Geohash.kt
@@ -1,11 +1,13 @@
 package org.maplibre.spatialk.geohash
 
 import kotlin.jvm.JvmStatic
+import kotlinx.serialization.Serializable
 import org.maplibre.spatialk.geohash.internal.BASE32_GHS
 import org.maplibre.spatialk.geohash.internal.base32GhsValue
 import org.maplibre.spatialk.geohash.internal.deinterleaveX
 import org.maplibre.spatialk.geohash.internal.deinterleaveY
 import org.maplibre.spatialk.geohash.internal.interleave
+import org.maplibre.spatialk.geohash.serialization.GeohashSerializer
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Position
 
@@ -15,6 +17,7 @@ import org.maplibre.spatialk.geojson.Position
  *
  * A `Geohash` is a cell rather than a string codec. Altitude is ignored.
  */
+@Serializable(with = GeohashSerializer::class)
 public class Geohash private constructor(private val packed: Long) : Comparable<Geohash> {
     /** Number of base32ghs characters in this cell's address. */
     public val length: Int
@@ -72,6 +75,22 @@ public class Geohash private constructor(private val packed: Long) : Comparable<
     /** The enclosing cell one character shorter, or `null` when [length] is `1`. */
     public val parent: Geohash?
         get() = if (length == 1) null else truncatedTo(length - 1)
+
+    /**
+     * The 32 finer cells, in base32ghs character order.
+     *
+     * Empty when [length] is [MaxLength].
+     */
+    public val children: List<Geohash>
+        get() {
+            if (length == MaxLength) return emptyList()
+            val childLength = length + 1
+            val shift = 64 - BitsPerCharacter * childLength
+            val payload = packed and LengthMask.inv()
+            return List(1 shl BitsPerCharacter) { index ->
+                Geohash(payload or (index.toLong() shl shift) or childLength.toLong())
+            }
+        }
 
     /**
      * The adjacent cells at this [length], with named compass directions.

--- a/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/Geohash.kt
+++ b/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/Geohash.kt
@@ -13,11 +13,7 @@ import org.maplibre.spatialk.geojson.Position
  * A rectangular cell on the WGS84 longitude and latitude plane, addressed by a
  * [Geohash](https://en.wikipedia.org/wiki/Geohash) string.
  *
- * A `Geohash` is a cell rather than a string codec. Its [text], [center], [boundingBox], [parent],
- * and [neighbors] are projections of one packed value. Altitude is ignored.
- *
- * Every instance is valid. Construction validates untrusted coordinates or text once, then cell
- * operations trust the instance.
+ * A `Geohash` is a cell rather than a string codec. Altitude is ignored.
  */
 public class Geohash private constructor(private val packed: Long) : Comparable<Geohash> {
     /** Number of base32ghs characters in this cell's address. */
@@ -151,10 +147,8 @@ public class Geohash private constructor(private val packed: Long) : Comparable<
      */
     override fun compareTo(other: Geohash): Int = packed.toULong().compareTo(other.packed.toULong())
 
-    /** Returns true when [other] identifies the same cell. */
     override fun equals(other: Any?): Boolean = other is Geohash && packed == other.packed
 
-    /** Returns a hash code consistent with [equals]. */
     override fun hashCode(): Int = packed.hashCode()
 
     /** Returns [text]. */

--- a/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/OsmShortlink.kt
+++ b/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/OsmShortlink.kt
@@ -78,6 +78,8 @@ private constructor(
 
         private const val BitsPerCharacter: Int = 6
         private const val BitsPerAxisPerCharacter: Int = 3
+        private const val FullAxisBits: Int = 32
+        private const val FullAxisCells: Long = 1L shl FullAxisBits
         private const val CharacterMask: Long = 0x3F
         private const val MinimumLongitude: Double = -180.0
         private const val MaximumLongitude: Double = 180.0
@@ -114,15 +116,8 @@ private constructor(
             }
 
             val axisBits = dataCharacterCount(zoom) * BitsPerAxisPerCharacter
-            val axisCells = 1 shl axisBits
-            val x =
-                (((position.longitude - MinimumLongitude) / LongitudeSpan) * axisCells)
-                    .toInt()
-                    .coerceAtMost(axisCells - 1)
-            val y =
-                (((position.latitude - MinimumLatitude) / LatitudeSpan) * axisCells)
-                    .toInt()
-                    .coerceAtMost(axisCells - 1)
+            val x = axisIndex(position.longitude, MinimumLongitude, LongitudeSpan, axisBits)
+            val y = axisIndex(position.latitude, MinimumLatitude, LatitudeSpan, axisBits)
             return OsmShortlink(interleave(x, axisBits, y, axisBits), zoom)
         }
 
@@ -189,6 +184,23 @@ private constructor(
 
         private fun paddingCount(zoom: Int): Int = (zoom + 8) % BitsPerAxisPerCharacter
 
+        private fun axisIndex(value: Double, minimum: Double, span: Double, axisBits: Int): Int {
+            val raw = (((value - minimum) / span) * FullAxisCells).toLong()
+            val wrapped = if (raw !in 0..<FullAxisCells) 0L else raw
+            return (wrapped ushr (FullAxisBits - axisBits)).toInt()
+        }
+
+        private fun hostFromAuthority(authority: String): String {
+            val colon = authority.indexOf(':')
+            if (colon < 0) return authority.lowercase()
+
+            val port = authority.substring(colon + 1)
+            require(port.isNotEmpty() && port.all { it.isDigit() }) {
+                "OpenStreetMap shortlink URL has an invalid authority"
+            }
+            return authority.substring(0, colon).lowercase()
+        }
+
         private fun extractCode(text: String): String {
             if (text.startsWith("/go/")) return codeFromPath(text)
 
@@ -208,7 +220,7 @@ private constructor(
             require(authority.isNotEmpty() && '@' !in authority) {
                 "OpenStreetMap shortlink URL has an invalid authority"
             }
-            val host = authority.substringBefore(':').lowercase()
+            val host = hostFromAuthority(authority)
             require(
                 host == "osm.org" ||
                     host == "www.osm.org" ||

--- a/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/OsmShortlink.kt
+++ b/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/OsmShortlink.kt
@@ -1,11 +1,13 @@
 package org.maplibre.spatialk.geohash
 
 import kotlin.jvm.JvmStatic
+import kotlinx.serialization.Serializable
 import org.maplibre.spatialk.geohash.internal.OSM_BASE64
 import org.maplibre.spatialk.geohash.internal.deinterleaveX
 import org.maplibre.spatialk.geohash.internal.deinterleaveY
 import org.maplibre.spatialk.geohash.internal.interleave
 import org.maplibre.spatialk.geohash.internal.osmBase64Value
+import org.maplibre.spatialk.geohash.serialization.OsmShortlinkSerializer
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Position
 
@@ -15,6 +17,7 @@ import org.maplibre.spatialk.geojson.Position
  * This sibling encoding is not a [Geohash]. It uses a modified base64 alphabet, carries a [zoom],
  * and has no cell hierarchy or neighbor operations.
  */
+@Serializable(with = OsmShortlinkSerializer::class)
 public class OsmShortlink
 private constructor(
     private val morton: Long,

--- a/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/OsmShortlink.kt
+++ b/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/OsmShortlink.kt
@@ -66,7 +66,6 @@ private constructor(
     override fun equals(other: Any?): Boolean =
         other is OsmShortlink && morton == other.morton && zoom == other.zoom
 
-    /** Returns a hash code consistent with [equals]. */
     override fun hashCode(): Int = 31 * morton.hashCode() + zoom
 
     /** Returns [text]. */

--- a/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/OsmShortlink.kt
+++ b/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/OsmShortlink.kt
@@ -1,0 +1,231 @@
+package org.maplibre.spatialk.geohash
+
+import kotlin.jvm.JvmStatic
+import org.maplibre.spatialk.geohash.internal.OSM_BASE64
+import org.maplibre.spatialk.geohash.internal.deinterleaveX
+import org.maplibre.spatialk.geohash.internal.deinterleaveY
+import org.maplibre.spatialk.geohash.internal.interleave
+import org.maplibre.spatialk.geohash.internal.osmBase64Value
+import org.maplibre.spatialk.geojson.BoundingBox
+import org.maplibre.spatialk.geojson.Position
+
+/**
+ * An [OpenStreetMap shortlink](https://wiki.openstreetmap.org/wiki/Shortlink).
+ *
+ * This sibling encoding is not a [Geohash]. It uses a modified base64 alphabet, carries a [zoom],
+ * and has no cell hierarchy or neighbor operations.
+ */
+public class OsmShortlink
+private constructor(
+    private val morton: Long,
+    /** The OpenStreetMap zoom level encoded by this shortlink. */
+    public val zoom: Int,
+) {
+    /** The canonical shortlink code without an `osm.org/go/` URL. */
+    public val text: String
+        get() {
+            val characterCount = dataCharacterCount(zoom)
+            return buildString(characterCount + paddingCount(zoom)) {
+                repeat(characterCount) { index ->
+                    val shift = 64 - BitsPerCharacter * (index + 1)
+                    append(OSM_BASE64[((morton ushr shift) and CharacterMask).toInt()])
+                }
+                repeat(paddingCount(zoom)) { append('-') }
+            }
+        }
+
+    /** The geometric center of the area addressed by this shortlink. */
+    public val center: Position
+        get() {
+            val box = boundingBox
+            return Position(
+                longitude = (box.west + box.east) / 2.0,
+                latitude = (box.south + box.north) / 2.0,
+            )
+        }
+
+    /** The two-dimensional area addressed by this shortlink. */
+    public val boundingBox: BoundingBox
+        get() {
+            val axisBits = dataCharacterCount(zoom) * BitsPerAxisPerCharacter
+            val x = deinterleaveX(morton, axisBits, axisBits)
+            val y = deinterleaveY(morton, axisBits, axisBits)
+            val longitudeStep = LongitudeSpan / (1L shl axisBits)
+            val latitudeStep = LatitudeSpan / (1L shl axisBits)
+            val west = MinimumLongitude + x * longitudeStep
+            val south = MinimumLatitude + y * latitudeStep
+            return BoundingBox(
+                west = west,
+                south = south,
+                east = west + longitudeStep,
+                north = south + latitudeStep,
+            )
+        }
+
+    /** Returns true when [other] has the same canonical code. */
+    override fun equals(other: Any?): Boolean =
+        other is OsmShortlink && morton == other.morton && zoom == other.zoom
+
+    /** Returns a hash code consistent with [equals]. */
+    override fun hashCode(): Int = 31 * morton.hashCode() + zoom
+
+    /** Returns [text]. */
+    override fun toString(): String = text
+
+    /** Factories for valid [OsmShortlink] values. */
+    public companion object {
+        /** The highest zoom supported by the OpenStreetMap 64-bit Morton layout. */
+        public const val MaxZoom: Int = 22
+
+        private const val BitsPerCharacter: Int = 6
+        private const val BitsPerAxisPerCharacter: Int = 3
+        private const val CharacterMask: Long = 0x3F
+        private const val MinimumLongitude: Double = -180.0
+        private const val MaximumLongitude: Double = 180.0
+        private const val MinimumLatitude: Double = -90.0
+        private const val MaximumLatitude: Double = 90.0
+        private const val LongitudeSpan: Double = 360.0
+        private const val LatitudeSpan: Double = 180.0
+
+        /**
+         * Returns the shortlink for [position] at [zoom].
+         *
+         * Longitude must be in `-180.0..180.0`, latitude must be in `-90.0..90.0`, and both values
+         * must be finite. Altitude is ignored.
+         *
+         * @throws IllegalArgumentException if the zoom or coordinate is invalid.
+         */
+        @JvmStatic
+        @Throws(IllegalArgumentException::class)
+        public fun of(position: Position, zoom: Int): OsmShortlink {
+            require(zoom in 0..MaxZoom) {
+                "OpenStreetMap shortlink zoom must be in 0..$MaxZoom, but was $zoom"
+            }
+            require(
+                position.longitude.isFinite() &&
+                    position.longitude in MinimumLongitude..MaximumLongitude
+            ) {
+                "Longitude must be finite and in $MinimumLongitude..$MaximumLongitude, but was ${position.longitude}"
+            }
+            require(
+                position.latitude.isFinite() &&
+                    position.latitude in MinimumLatitude..MaximumLatitude
+            ) {
+                "Latitude must be finite and in $MinimumLatitude..$MaximumLatitude, but was ${position.latitude}"
+            }
+
+            val axisBits = dataCharacterCount(zoom) * BitsPerAxisPerCharacter
+            val axisCells = 1 shl axisBits
+            val x =
+                (((position.longitude - MinimumLongitude) / LongitudeSpan) * axisCells)
+                    .toInt()
+                    .coerceAtMost(axisCells - 1)
+            val y =
+                (((position.latitude - MinimumLatitude) / LatitudeSpan) * axisCells)
+                    .toInt()
+                    .coerceAtMost(axisCells - 1)
+            return OsmShortlink(interleave(x, axisBits, y, axisBits), zoom)
+        }
+
+        /**
+         * Parses a shortlink code, `/go/` path, or OpenStreetMap URL.
+         *
+         * URLs may use `osm.org`, `www.osm.org`, `openstreetmap.org`, or `www.openstreetmap.org`.
+         * Historical `@` and `=` characters are accepted and [text] emits `~` and `-`.
+         *
+         * @throws IllegalArgumentException if [text] is not a valid OpenStreetMap shortlink.
+         */
+        @JvmStatic
+        @Throws(IllegalArgumentException::class)
+        public fun parse(text: String): OsmShortlink {
+            val code = extractCode(text).replace('@', '~').replace('=', '-')
+            require(code.isNotEmpty()) { "OpenStreetMap shortlink code must not be empty" }
+
+            val firstPadding = code.indexOf('-').let { if (it < 0) code.length else it }
+            val data = code.substring(0, firstPadding)
+            val padding = code.length - firstPadding
+            require(padding in 0..2 && code.drop(firstPadding).all { it == '-' }) {
+                "OpenStreetMap shortlink padding must be zero, one, or two trailing '-' characters"
+            }
+            require(data.isNotEmpty()) {
+                "OpenStreetMap shortlink code must contain data characters"
+            }
+
+            var morton = 0L
+            data.forEachIndexed { index, char ->
+                val value = osmBase64Value(char)
+                require(value >= 0) {
+                    "Invalid OpenStreetMap shortlink character '$char' at index $index"
+                }
+                val shift = 64 - BitsPerCharacter * (index + 1)
+                require(shift >= 0) { "OpenStreetMap shortlink code is too long" }
+                morton = morton or (value.toLong() shl shift)
+            }
+
+            val zoom =
+                data.length * BitsPerAxisPerCharacter -
+                    8 -
+                    when (padding) {
+                        0 -> 0
+                        1 -> 2
+                        else -> 1
+                    }
+            require(zoom in 0..MaxZoom) {
+                "OpenStreetMap shortlink zoom must be in 0..$MaxZoom, but was $zoom"
+            }
+            return OsmShortlink(morton, zoom)
+        }
+
+        /** Parses an OpenStreetMap shortlink, or returns `null` when [text] is invalid. */
+        @JvmStatic
+        public fun parseOrNull(text: String): OsmShortlink? =
+            try {
+                parse(text)
+            } catch (_: IllegalArgumentException) {
+                null
+            }
+
+        private fun dataCharacterCount(zoom: Int): Int =
+            (zoom + 8 + BitsPerAxisPerCharacter - 1) / BitsPerAxisPerCharacter
+
+        private fun paddingCount(zoom: Int): Int = (zoom + 8) % BitsPerAxisPerCharacter
+
+        private fun extractCode(text: String): String {
+            if (text.startsWith("/go/")) return codeFromPath(text)
+
+            val schemeEnd = text.indexOf("://")
+            if (schemeEnd < 0) return text
+
+            val scheme = text.substring(0, schemeEnd).lowercase()
+            require(scheme == "http" || scheme == "https") {
+                "OpenStreetMap shortlink URL must use HTTP or HTTPS"
+            }
+            val remainder = text.substring(schemeEnd + 3)
+            val authorityEnd =
+                remainder.indexOfAny(charArrayOf('/', '?', '#')).let {
+                    if (it < 0) remainder.length else it
+                }
+            val authority = remainder.substring(0, authorityEnd)
+            require(authority.isNotEmpty() && '@' !in authority) {
+                "OpenStreetMap shortlink URL has an invalid authority"
+            }
+            val host = authority.substringBefore(':').lowercase()
+            require(
+                host == "osm.org" ||
+                    host == "www.osm.org" ||
+                    host == "openstreetmap.org" ||
+                    host == "www.openstreetmap.org"
+            ) {
+                "OpenStreetMap shortlink URL has an unsupported host"
+            }
+            return codeFromPath(remainder.substring(authorityEnd))
+        }
+
+        private fun codeFromPath(path: String): String {
+            require(path.startsWith("/go/")) {
+                "OpenStreetMap shortlink path must start with /go/"
+            }
+            return path.removePrefix("/go/").substringBefore('?').substringBefore('#')
+        }
+    }
+}

--- a/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/OsmShortlink.kt
+++ b/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/OsmShortlink.kt
@@ -198,7 +198,7 @@ private constructor(
             if (colon < 0) return authority.lowercase()
 
             val port = authority.substring(colon + 1)
-            require(port.isNotEmpty() && port.all { it.isDigit() }) {
+            require(port.isNotEmpty() && port.all { it in '0'..'9' }) {
                 "OpenStreetMap shortlink URL has an invalid authority"
             }
             return authority.substring(0, colon).lowercase()

--- a/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/internal/Alphabets.kt
+++ b/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/internal/Alphabets.kt
@@ -1,0 +1,25 @@
+package org.maplibre.spatialk.geohash.internal
+
+internal const val BASE32_GHS: String = "0123456789bcdefghjkmnpqrstuvwxyz"
+
+internal const val OSM_BASE64: String =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_~"
+
+private val base32GhsValues =
+    IntArray(128) { -1 }
+        .apply {
+            BASE32_GHS.forEachIndexed { index, char -> this[char.code] = index }
+        }
+
+private val osmBase64Values =
+    IntArray(128) { -1 }
+        .apply {
+            OSM_BASE64.forEachIndexed { index, char -> this[char.code] = index }
+            this['@'.code] = OSM_BASE64.lastIndex
+        }
+
+internal fun base32GhsValue(char: Char): Int =
+    if (char.code < base32GhsValues.size) base32GhsValues[char.code] else -1
+
+internal fun osmBase64Value(char: Char): Int =
+    if (char.code < osmBase64Values.size) osmBase64Values[char.code] else -1

--- a/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/internal/Morton.kt
+++ b/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/internal/Morton.kt
@@ -1,0 +1,34 @@
+package org.maplibre.spatialk.geohash.internal
+
+internal fun interleave(x: Int, xBits: Int, y: Int, yBits: Int): Long {
+    val totalBits = xBits + yBits
+    var morton = 0L
+
+    for (index in 0..<totalBits) {
+        val bit =
+            if (index % 2 == 0) {
+                (x ushr (xBits - 1 - index / 2)) and 1
+            } else {
+                (y ushr (yBits - 1 - index / 2)) and 1
+            }
+        morton = morton or (bit.toLong() shl (63 - index))
+    }
+
+    return morton
+}
+
+internal fun deinterleaveX(morton: Long, xBits: Int, yBits: Int): Int {
+    var x = 0
+    for (index in 0..<(xBits + yBits) step 2) {
+        x = (x shl 1) or ((morton ushr (63 - index)) and 1L).toInt()
+    }
+    return x
+}
+
+internal fun deinterleaveY(morton: Long, xBits: Int, yBits: Int): Int {
+    var y = 0
+    for (index in 1..<(xBits + yBits) step 2) {
+        y = (y shl 1) or ((morton ushr (63 - index)) and 1L).toInt()
+    }
+    return y
+}

--- a/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/serialization/GeohashSerializer.kt
+++ b/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/serialization/GeohashSerializer.kt
@@ -1,0 +1,29 @@
+package org.maplibre.spatialk.geohash.serialization
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import org.maplibre.spatialk.geohash.Geohash
+
+/** Serializes a [Geohash] as its canonical lowercase address. */
+internal object GeohashSerializer : KSerializer<Geohash> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("org.maplibre.spatialk.geohash.Geohash", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: Geohash) {
+        encoder.encodeString(value.text)
+    }
+
+    override fun deserialize(decoder: Decoder): Geohash {
+        val text = decoder.decodeString()
+        return try {
+            Geohash.parse(text)
+        } catch (cause: IllegalArgumentException) {
+            throw SerializationException("Invalid geohash '$text'", cause)
+        }
+    }
+}

--- a/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/serialization/OsmShortlinkSerializer.kt
+++ b/geohash/src/commonMain/kotlin/org/maplibre/spatialk/geohash/serialization/OsmShortlinkSerializer.kt
@@ -1,0 +1,32 @@
+package org.maplibre.spatialk.geohash.serialization
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import org.maplibre.spatialk.geohash.OsmShortlink
+
+/** Serializes an [OsmShortlink] as its canonical shortlink code. */
+internal object OsmShortlinkSerializer : KSerializer<OsmShortlink> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor(
+            "org.maplibre.spatialk.geohash.OsmShortlink",
+            PrimitiveKind.STRING,
+        )
+
+    override fun serialize(encoder: Encoder, value: OsmShortlink) {
+        encoder.encodeString(value.text)
+    }
+
+    override fun deserialize(decoder: Decoder): OsmShortlink {
+        val text = decoder.decodeString()
+        return try {
+            OsmShortlink.parse(text)
+        } catch (cause: IllegalArgumentException) {
+            throw SerializationException("Invalid OpenStreetMap shortlink '$text'", cause)
+        }
+    }
+}

--- a/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/Fixtures.kt
+++ b/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/Fixtures.kt
@@ -1,0 +1,88 @@
+package org.maplibre.spatialk.geohash
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.maplibre.spatialk.testutil.readResourceFile
+
+/** Vectors from `commonTest/resources`. Provenance is in `resources/README.md`. */
+internal object GeohashFixtures {
+    val geohashEncode: List<GeohashEncodeCase> = load("geohash/encode.json")
+    val geohashDecode: List<GeohashDecodeCase> = load("geohash/decode.json")
+    val geohashNeighbors: List<GeohashNeighborCase> = load("geohash/neighbors.json")
+    val geohashNeighborSteps: List<GeohashNeighborStepCase> = load("geohash/neighbor_steps.json")
+    val osmEncode: List<OsmEncodeCase> = load("osm/encode.json")
+    val osmParse: List<OsmParseCase> = load("osm/parse.json")
+
+    private inline fun <reified T> load(path: String): List<T> {
+        val value = Json.decodeFromString<List<T>>(readResourceFile(path))
+        check(value.isNotEmpty()) { "Fixture $path must not be empty" }
+        return value
+    }
+}
+
+@Serializable
+internal data class GeohashEncodeCase(
+    val source: String,
+    val longitude: Double,
+    val latitude: Double,
+    val length: Int,
+    val text: String,
+)
+
+@Serializable
+internal data class GeohashDecodeCase(
+    val source: String,
+    val text: String,
+    val longitude: Double,
+    val latitude: Double,
+    val west: Double? = null,
+    val south: Double? = null,
+    val east: Double? = null,
+    val north: Double? = null,
+)
+
+@Serializable
+internal data class GeohashNeighborCase(
+    val source: String,
+    val text: String,
+    val north: String,
+    val northEast: String,
+    val east: String,
+    val southEast: String,
+    val south: String,
+    val southWest: String,
+    val west: String,
+    val northWest: String,
+)
+
+@Serializable
+internal data class GeohashNeighborStepCase(
+    val source: String,
+    val text: String,
+    val east: Int,
+    val north: Int,
+    val expected: String,
+)
+
+@Serializable
+internal data class OsmEncodeCase(
+    val name: String,
+    val longitude: Double,
+    val latitude: Double,
+    val zoom: Int,
+    val text: String,
+)
+
+@Serializable
+internal data class OsmParseCase(
+    val source: String,
+    val input: String,
+    val text: String,
+    val zoom: Int? = null,
+    val longitude: Double? = null,
+    val latitude: Double? = null,
+    val west: Double? = null,
+    val south: Double? = null,
+    val east: Double? = null,
+    val north: Double? = null,
+)

--- a/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/GeohashTest.kt
+++ b/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/GeohashTest.kt
@@ -1,0 +1,122 @@
+package org.maplibre.spatialk.geohash
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.testutil.assertDoubleEquals
+import org.maplibre.spatialk.testutil.assertPositionEquals
+
+class GeohashTest {
+    @Test
+    fun `encodes Wikipedia vectors`() {
+        assertEquals(
+            "u4pruydqqvj",
+            Geohash.of(
+                    Position(longitude = 10.40744, latitude = 57.64911),
+                    length = 11,
+                )
+                .text,
+        )
+        assertEquals(
+            "ezs42",
+            Geohash.of(
+                    Position(longitude = -5.60302734375, latitude = 42.60498046875),
+                    length = 5,
+                )
+                .text,
+        )
+    }
+
+    @Test
+    fun `decodes the Wikipedia center and bounding box`() {
+        val cell = Geohash.parse("ezs42")
+
+        assertPositionEquals(
+            Position(longitude = -5.60302734375, latitude = 42.60498046875),
+            cell.center,
+        )
+        assertDoubleEquals(-5.625, cell.boundingBox.west)
+        assertDoubleEquals(42.5830078125, cell.boundingBox.south)
+        assertDoubleEquals(-5.5810546875, cell.boundingBox.east)
+        assertDoubleEquals(42.626953125, cell.boundingBox.north)
+    }
+
+    @Test
+    fun `parse folds ASCII case and emits lowercase`() {
+        val cell = Geohash.parse("U4PRUYDQQVJ")
+
+        assertEquals("u4pruydqqvj", cell.text)
+        assertEquals(cell, Geohash.parse(cell.text))
+        assertEquals(cell.text, cell.toString())
+        assertEquals(11, cell.length)
+        assertNotNull(Geohash.parseOrNull("EzS42"))
+    }
+
+    @Test
+    fun `rejects invalid text`() {
+        listOf("", "a", "i", "l", "o", "ezs42!", "0000000000000").forEach { text ->
+            assertFailsWith<IllegalArgumentException>(text) { Geohash.parse(text) }
+            assertNull(Geohash.parseOrNull(text), text)
+        }
+    }
+
+    @Test
+    fun `validates length and coordinates at construction`() {
+        val origin = Position(longitude = 0.0, latitude = 0.0)
+        assertFailsWith<IllegalArgumentException> { Geohash.of(origin, length = 0) }
+        assertFailsWith<IllegalArgumentException> { Geohash.of(origin, length = 13) }
+        assertFailsWith<IllegalArgumentException> {
+            Geohash.of(Position(longitude = -180.0001, latitude = 0.0), length = 5)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            Geohash.of(Position(longitude = 180.0001, latitude = 0.0), length = 5)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            Geohash.of(Position(longitude = 0.0, latitude = -90.0001), length = 5)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            Geohash.of(Position(longitude = 0.0, latitude = 90.0001), length = 5)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            Geohash.of(Position(longitude = Double.NaN, latitude = 0.0), length = 5)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            Geohash.of(Position(longitude = 0.0, latitude = Double.POSITIVE_INFINITY), length = 5)
+        }
+    }
+
+    @Test
+    fun `accepts coordinate edges and ignores altitude`() {
+        val northeast =
+            Geohash.of(Position(longitude = 180.0, latitude = 90.0, altitude = 100.0), length = 12)
+        val southwest = Geohash.of(Position(longitude = -180.0, latitude = -90.0), length = 12)
+
+        assertEquals(12, northeast.length)
+        assertEquals(12, southwest.length)
+        assertEquals(
+            northeast,
+            Geohash.of(Position(longitude = 180.0, latitude = 90.0), length = 12),
+        )
+        assertEquals(northeast, Geohash.of(northeast.center, length = northeast.length))
+        assertEquals(southwest, Geohash.of(southwest.center, length = southwest.length))
+    }
+
+    @Test
+    fun `packed order equals text order across mixed lengths`() {
+        val alphabet = "0123456789bcdefghjkmnpqrstuvwxyz"
+        val texts = buildList {
+            addAll(listOf("0", "z", "e", "ez", "ezs", "ezs4", "ezs42"))
+            alphabet.forEach { add("ezs42$it") }
+            addAll(listOf("b", "bc", "u4pruydqqvj", "zzzzzzzzzzzz"))
+        }
+        val cells = texts.map(Geohash::parse)
+
+        assertEquals(texts.sorted(), cells.sorted().map(Geohash::text))
+        assertEquals(cells.size, cells.toSet().size)
+        assertTrue(Geohash.parse("ezs42") < Geohash.parse("ezs420"))
+    }
+}

--- a/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/GeohashTest.kt
+++ b/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/GeohashTest.kt
@@ -134,6 +134,22 @@ class GeohashTest {
     }
 
     @Test
+    fun `returns children in base32ghs order`() {
+        val cell = Geohash.parse("ezs42")
+        val children = cell.children
+        val alphabet = "0123456789bcdefghjkmnpqrstuvwxyz"
+
+        assertEquals(32, children.size)
+        assertEquals(alphabet.map { "ezs42$it" }, children.map(Geohash::text))
+        children.forEach { child ->
+            assertEquals(cell, child.parent)
+            assertTrue(child in cell)
+            assertEquals(cell, child.truncatedTo(cell.length))
+        }
+        assertEquals(emptyList(), Geohash.parse("zzzzzzzzzzzz").children)
+    }
+
+    @Test
     fun `returns libgeohash neighbors in compass order`() {
         val neighbors = Geohash.parse("ezs42").neighbors
 

--- a/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/GeohashTest.kt
+++ b/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/GeohashTest.kt
@@ -3,6 +3,7 @@ package org.maplibre.spatialk.geohash
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -118,5 +119,74 @@ class GeohashTest {
         assertEquals(texts.sorted(), cells.sorted().map(Geohash::text))
         assertEquals(cells.size, cells.toSet().size)
         assertTrue(Geohash.parse("ezs42") < Geohash.parse("ezs420"))
+    }
+
+    @Test
+    fun `returns parent and truncates to an enclosing cell`() {
+        val cell = Geohash.parse("u4pruydqqvj")
+
+        assertEquals("u4pruydqqv", cell.parent?.text)
+        assertEquals("u4pru", cell.truncatedTo(5).text)
+        assertEquals(cell, cell.truncatedTo(cell.length))
+        assertNull(Geohash.parse("u").parent)
+        assertFailsWith<IllegalArgumentException> { cell.truncatedTo(0) }
+        assertFailsWith<IllegalArgumentException> { cell.truncatedTo(cell.length + 1) }
+    }
+
+    @Test
+    fun `returns libgeohash neighbors in compass order`() {
+        val neighbors = Geohash.parse("ezs42").neighbors
+
+        assertEquals("ezs48", neighbors.north?.text)
+        assertEquals("ezs49", neighbors.northEast?.text)
+        assertEquals("ezs43", neighbors.east.text)
+        assertEquals("ezs41", neighbors.southEast?.text)
+        assertEquals("ezs40", neighbors.south?.text)
+        assertEquals("ezefp", neighbors.southWest?.text)
+        assertEquals("ezefr", neighbors.west.text)
+        assertEquals("ezefx", neighbors.northWest?.text)
+        assertEquals(
+            listOf("ezs48", "ezs49", "ezs43", "ezs41", "ezs40", "ezefp", "ezefr", "ezefx"),
+            neighbors.toList().map(Geohash::text),
+        )
+    }
+
+    @Test
+    fun `wraps longitude and rejects offsets past the poles`() {
+        val cell = Geohash.parse("b")
+        assertEquals(cell, cell.offsetBy(east = 1, north = 0)?.offsetBy(east = -1, north = 0))
+        assertEquals(
+            cell,
+            cell
+                .offsetBy(east = Int.MAX_VALUE, north = 0)
+                ?.offsetBy(east = -Int.MAX_VALUE, north = 0),
+        )
+
+        val top = Geohash.of(Position(longitude = 0.0, latitude = 90.0), length = 3).neighbors
+        assertNull(top.north)
+        assertNull(top.northEast)
+        assertNull(top.northWest)
+        assertEquals(5, top.toList().size)
+
+        val bottom = Geohash.of(Position(longitude = 0.0, latitude = -90.0), length = 3).neighbors
+        assertNull(bottom.south)
+        assertNull(bottom.southEast)
+        assertNull(bottom.southWest)
+        assertEquals(5, bottom.toList().size)
+    }
+
+    @Test
+    fun `contains positions and descendant cells`() {
+        val cell = Geohash.parse("ezs42")
+        val parent = cell.parent!!
+
+        assertTrue(cell.center in cell)
+        assertFalse(cell.neighbors.east.center in cell)
+        assertTrue(cell in parent)
+        assertTrue(parent in parent)
+        assertFalse(parent in cell)
+        assertFailsWith<IllegalArgumentException> {
+            Position(longitude = Double.NaN, latitude = 0.0) in cell
+        }
     }
 }

--- a/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/GeohashTest.kt
+++ b/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/GeohashTest.kt
@@ -13,37 +13,40 @@ import org.maplibre.spatialk.testutil.assertPositionEquals
 
 class GeohashTest {
     @Test
-    fun `encodes Wikipedia vectors`() {
-        assertEquals(
-            "u4pruydqqvj",
-            Geohash.of(
-                    Position(longitude = 10.40744, latitude = 57.64911),
-                    length = 11,
-                )
-                .text,
-        )
-        assertEquals(
-            "ezs42",
-            Geohash.of(
-                    Position(longitude = -5.60302734375, latitude = 42.60498046875),
-                    length = 5,
-                )
-                .text,
-        )
+    fun `encodes imported vectors`() {
+        GeohashFixtures.geohashEncode.forEach { case ->
+            val label = "${case.source} ${case.text}"
+            assertEquals(
+                case.text,
+                Geohash.of(
+                        Position(longitude = case.longitude, latitude = case.latitude),
+                        length = case.length,
+                    )
+                    .text,
+                label,
+            )
+        }
     }
 
     @Test
-    fun `decodes the Wikipedia center and bounding box`() {
-        val cell = Geohash.parse("ezs42")
-
-        assertPositionEquals(
-            Position(longitude = -5.60302734375, latitude = 42.60498046875),
-            cell.center,
-        )
-        assertDoubleEquals(-5.625, cell.boundingBox.west)
-        assertDoubleEquals(42.5830078125, cell.boundingBox.south)
-        assertDoubleEquals(-5.5810546875, cell.boundingBox.east)
-        assertDoubleEquals(42.626953125, cell.boundingBox.north)
+    fun `decodes imported vectors`() {
+        GeohashFixtures.geohashDecode.forEach { case ->
+            val label = "${case.source} ${case.text}"
+            val cell = Geohash.parse(case.text)
+            assertPositionEquals(
+                Position(longitude = case.longitude, latitude = case.latitude),
+                cell.center,
+                message = label,
+            )
+            if (
+                case.west != null && case.south != null && case.east != null && case.north != null
+            ) {
+                assertDoubleEquals(case.west, cell.boundingBox.west, message = label)
+                assertDoubleEquals(case.south, cell.boundingBox.south, message = label)
+                assertDoubleEquals(case.east, cell.boundingBox.east, message = label)
+                assertDoubleEquals(case.north, cell.boundingBox.north, message = label)
+            }
+        }
     }
 
     @Test
@@ -150,21 +153,45 @@ class GeohashTest {
     }
 
     @Test
-    fun `returns libgeohash neighbors in compass order`() {
-        val neighbors = Geohash.parse("ezs42").neighbors
+    fun `returns imported neighbors in compass order`() {
+        GeohashFixtures.geohashNeighbors.forEach { case ->
+            val label = "${case.source} ${case.text}"
+            val neighbors = Geohash.parse(case.text).neighbors
+            assertEquals(case.north, neighbors.north?.text, label)
+            assertEquals(case.northEast, neighbors.northEast?.text, label)
+            assertEquals(case.east, neighbors.east.text, label)
+            assertEquals(case.southEast, neighbors.southEast?.text, label)
+            assertEquals(case.south, neighbors.south?.text, label)
+            assertEquals(case.southWest, neighbors.southWest?.text, label)
+            assertEquals(case.west, neighbors.west.text, label)
+            assertEquals(case.northWest, neighbors.northWest?.text, label)
+            assertEquals(
+                listOf(
+                    case.north,
+                    case.northEast,
+                    case.east,
+                    case.southEast,
+                    case.south,
+                    case.southWest,
+                    case.west,
+                    case.northWest,
+                ),
+                neighbors.toList().map(Geohash::text),
+                label,
+            )
+        }
+    }
 
-        assertEquals("ezs48", neighbors.north?.text)
-        assertEquals("ezs49", neighbors.northEast?.text)
-        assertEquals("ezs43", neighbors.east.text)
-        assertEquals("ezs41", neighbors.southEast?.text)
-        assertEquals("ezs40", neighbors.south?.text)
-        assertEquals("ezefp", neighbors.southWest?.text)
-        assertEquals("ezefr", neighbors.west.text)
-        assertEquals("ezefx", neighbors.northWest?.text)
-        assertEquals(
-            listOf("ezs48", "ezs49", "ezs43", "ezs41", "ezs40", "ezefp", "ezefr", "ezefx"),
-            neighbors.toList().map(Geohash::text),
-        )
+    @Test
+    fun `walks imported neighbor steps`() {
+        GeohashFixtures.geohashNeighborSteps.forEach { case ->
+            val label = "${case.source} ${case.text} east=${case.east} north=${case.north}"
+            assertEquals(
+                case.expected,
+                Geohash.parse(case.text).offsetBy(east = case.east, north = case.north)?.text,
+                label,
+            )
+        }
     }
 
     @Test

--- a/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt
+++ b/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt
@@ -1,0 +1,65 @@
+@file:Suppress("UnusedVariable", "unused")
+
+package org.maplibre.spatialk.geohash
+
+import kotlin.test.Test
+import org.maplibre.spatialk.geojson.Position
+
+class KotlinDocsTest {
+    @Test
+    fun encode() {
+        // --8<-- [start:encode]
+        val cell =
+            Geohash.of(
+                Position(longitude = 10.40744, latitude = 57.64911),
+                length = 11,
+            )
+        println(cell.text)
+        // u4pruydqqvj
+        // --8<-- [end:encode]
+    }
+
+    @Test
+    fun parse() {
+        // --8<-- [start:parse]
+        val cell = Geohash.parse("ezs42")
+        val center = cell.center
+        val boundingBox = cell.boundingBox
+        val parent = cell.parent
+        // --8<-- [end:parse]
+    }
+
+    @Test
+    fun neighbors() {
+        // --8<-- [start:neighbors]
+        val cell = Geohash.parse("ezs42")
+        val east = cell.neighbors.east
+        val existingNeighbors = cell.neighbors.toList()
+        val twoCellsWest = cell.offsetBy(east = -2, north = 0)
+        // --8<-- [end:neighbors]
+    }
+
+    @Test
+    fun containment() {
+        // --8<-- [start:containment]
+        val cell = Geohash.parse("ezs42")
+        val containsCenter = cell.center in cell
+        val containsChild = Geohash.parse("ezs420") in cell
+        // --8<-- [end:containment]
+    }
+
+    @Test
+    fun osmShortlink() {
+        // --8<-- [start:osmShortlink]
+        val shortlink = OsmShortlink.parse("https://osm.org/go/0EEQjE--")
+        println(shortlink.zoom)
+        println(shortlink.center)
+
+        val encoded =
+            OsmShortlink.of(
+                Position(longitude = 0.054, latitude = 51.510),
+                zoom = 9,
+            )
+        // --8<-- [end:osmShortlink]
+    }
+}

--- a/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt
+++ b/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/KotlinDocsTest.kt
@@ -3,6 +3,9 @@
 package org.maplibre.spatialk.geohash
 
 import kotlin.test.Test
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.maplibre.spatialk.geojson.Position
 
 class KotlinDocsTest {
@@ -26,6 +29,7 @@ class KotlinDocsTest {
         val center = cell.center
         val boundingBox = cell.boundingBox
         val parent = cell.parent
+        val children = cell.children
         // --8<-- [end:parse]
     }
 
@@ -61,5 +65,14 @@ class KotlinDocsTest {
                 zoom = 9,
             )
         // --8<-- [end:osmShortlink]
+    }
+
+    @Test
+    fun serialize() {
+        // --8<-- [start:serialize]
+        val cell = Geohash.parse("ezs42")
+        val json = Json.encodeToString(cell)
+        val parsed = Json.decodeFromString<Geohash>(json)
+        // --8<-- [end:serialize]
     }
 }

--- a/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/OsmShortlinkTest.kt
+++ b/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/OsmShortlinkTest.kt
@@ -1,0 +1,116 @@
+package org.maplibre.spatialk.geohash
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.testutil.assertDoubleEquals
+import org.maplibre.spatialk.testutil.assertPositionEquals
+
+class OsmShortlinkTest {
+    @Test
+    fun `parses the London shortlink`() {
+        val shortlink = OsmShortlink.parse("https://osm.org/go/0EEQjE--")
+
+        assertEquals("0EEQjE--", shortlink.text)
+        assertEquals(9, shortlink.zoom)
+        assertPositionEquals(
+            Position(longitude = 0.0556182861328125, latitude = 51.51111602783203),
+            shortlink.center,
+        )
+        assertDoubleEquals(0.054931640625, shortlink.boundingBox.west)
+        assertDoubleEquals(51.510772705078125, shortlink.boundingBox.south)
+        assertDoubleEquals(0.056304931640625, shortlink.boundingBox.east)
+        assertDoubleEquals(51.51145935058594, shortlink.boundingBox.north)
+        assertEquals(shortlink, OsmShortlink.of(shortlink.center, shortlink.zoom))
+        assertEquals(shortlink.text, shortlink.toString())
+    }
+
+    @Test
+    fun `encodes the OpenStreetMap Rails vector`() {
+        val shortlink =
+            OsmShortlink.of(
+                Position(longitude = 0.054, latitude = 51.510),
+                zoom = 9,
+            )
+
+        assertEquals("0EEQhq--", shortlink.text)
+    }
+
+    @Test
+    fun `parses bare codes paths and supported URLs`() {
+        val expected = OsmShortlink.parse("0EEQjE--")
+
+        assertEquals(expected, OsmShortlink.parse("/go/0EEQjE--"))
+        assertEquals(expected, OsmShortlink.parse("/go/0EEQjE--?m="))
+        assertEquals(expected, OsmShortlink.parse("http://www.osm.org/go/0EEQjE--#map=9"))
+        assertEquals(
+            expected,
+            OsmShortlink.parse("https://openstreetmap.org/go/0EEQjE--?m="),
+        )
+        assertEquals(
+            expected,
+            OsmShortlink.parse("HTTPS://WWW.OPENSTREETMAP.ORG/go/0EEQjE--"),
+        )
+    }
+
+    @Test
+    fun `normalizes historical shortlink characters`() {
+        assertEquals("0EEQjE--", OsmShortlink.parse("0EEQjE==").text)
+        assertEquals("0OP4tR~rx", OsmShortlink.parse("0OP4tR@rx").text)
+    }
+
+    @Test
+    fun `supports the full zoom range`() {
+        val position = Position(longitude = 12.345678, latitude = -45.678912, altitude = 50.0)
+        val minimum = OsmShortlink.of(position, zoom = 0)
+        val maximum = OsmShortlink.of(position, zoom = OsmShortlink.MaxZoom)
+
+        assertEquals(0, minimum.zoom)
+        assertEquals(OsmShortlink.MaxZoom, maximum.zoom)
+        assertEquals(minimum, OsmShortlink.parse(minimum.text))
+        assertEquals(maximum, OsmShortlink.parse(maximum.text))
+        assertEquals(
+            maximum,
+            OsmShortlink.of(
+                Position(
+                    longitude = position.longitude,
+                    latitude = position.latitude,
+                ),
+                zoom = OsmShortlink.MaxZoom,
+            ),
+        )
+    }
+
+    @Test
+    fun `rejects invalid zoom coordinates codes and URLs`() {
+        val origin = Position(longitude = 0.0, latitude = 0.0)
+        assertFailsWith<IllegalArgumentException> { OsmShortlink.of(origin, zoom = -1) }
+        assertFailsWith<IllegalArgumentException> {
+            OsmShortlink.of(origin, zoom = OsmShortlink.MaxZoom + 1)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            OsmShortlink.of(Position(longitude = Double.NaN, latitude = 0.0), zoom = 9)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            OsmShortlink.of(Position(longitude = 0.0, latitude = 90.1), zoom = 9)
+        }
+
+        listOf(
+                "",
+                "/go/",
+                "AA",
+                "ABC+--",
+                "ABC---",
+                "AB-C",
+                "AAAAAAAAAAA",
+                "https://example.com/go/0EEQjE--",
+                "https://osm.org/map/0EEQjE--",
+            )
+            .forEach { text ->
+                assertFailsWith<IllegalArgumentException>(text) { OsmShortlink.parse(text) }
+                assertNull(OsmShortlink.parseOrNull(text), text)
+            }
+    }
+}

--- a/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/OsmShortlinkTest.kt
+++ b/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/OsmShortlinkTest.kt
@@ -10,32 +10,48 @@ import org.maplibre.spatialk.testutil.assertPositionEquals
 
 class OsmShortlinkTest {
     @Test
-    fun `parses the London shortlink`() {
-        val shortlink = OsmShortlink.parse("https://osm.org/go/0EEQjE--")
-
-        assertEquals("0EEQjE--", shortlink.text)
-        assertEquals(9, shortlink.zoom)
-        assertPositionEquals(
-            Position(longitude = 0.0556182861328125, latitude = 51.51111602783203),
-            shortlink.center,
-        )
-        assertDoubleEquals(0.054931640625, shortlink.boundingBox.west)
-        assertDoubleEquals(51.510772705078125, shortlink.boundingBox.south)
-        assertDoubleEquals(0.056304931640625, shortlink.boundingBox.east)
-        assertDoubleEquals(51.51145935058594, shortlink.boundingBox.north)
-        assertEquals(shortlink, OsmShortlink.of(shortlink.center, shortlink.zoom))
-        assertEquals(shortlink.text, shortlink.toString())
+    fun `encodes generated shortlink vectors`() {
+        GeohashFixtures.osmEncode.forEach { case ->
+            val label = "${case.name} ${case.text}"
+            assertEquals(
+                case.text,
+                OsmShortlink.of(
+                        Position(longitude = case.longitude, latitude = case.latitude),
+                        zoom = case.zoom,
+                    )
+                    .text,
+                label,
+            )
+        }
     }
 
     @Test
-    fun `encodes the OpenStreetMap Rails vector`() {
-        val shortlink =
-            OsmShortlink.of(
-                Position(longitude = 0.054, latitude = 51.510),
-                zoom = 9,
-            )
-
-        assertEquals("0EEQhq--", shortlink.text)
+    fun `parses imported shortlink vectors`() {
+        GeohashFixtures.osmParse.forEach { case ->
+            val label = "${case.source} ${case.input}"
+            val shortlink = OsmShortlink.parse(case.input)
+            assertEquals(case.text, shortlink.text, label)
+            assertEquals(case.text, shortlink.toString(), label)
+            if (case.zoom != null) {
+                assertEquals(case.zoom, shortlink.zoom, label)
+                assertEquals(shortlink, OsmShortlink.of(shortlink.center, shortlink.zoom), label)
+            }
+            if (case.longitude != null && case.latitude != null) {
+                assertPositionEquals(
+                    Position(longitude = case.longitude, latitude = case.latitude),
+                    shortlink.center,
+                    message = label,
+                )
+            }
+            if (
+                case.west != null && case.south != null && case.east != null && case.north != null
+            ) {
+                assertDoubleEquals(case.west, shortlink.boundingBox.west, message = label)
+                assertDoubleEquals(case.south, shortlink.boundingBox.south, message = label)
+                assertDoubleEquals(case.east, shortlink.boundingBox.east, message = label)
+                assertDoubleEquals(case.north, shortlink.boundingBox.north, message = label)
+            }
+        }
     }
 
     @Test
@@ -54,12 +70,6 @@ class OsmShortlinkTest {
             OsmShortlink.parse("HTTPS://WWW.OPENSTREETMAP.ORG/go/0EEQjE--"),
         )
         assertEquals(expected, OsmShortlink.parse("https://osm.org:443/go/0EEQjE--"))
-    }
-
-    @Test
-    fun `normalizes historical shortlink characters`() {
-        assertEquals("0EEQjE--", OsmShortlink.parse("0EEQjE==").text)
-        assertEquals("0OP4tR~rx", OsmShortlink.parse("0OP4tR@rx").text)
     }
 
     @Test

--- a/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/OsmShortlinkTest.kt
+++ b/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/OsmShortlinkTest.kt
@@ -53,6 +53,7 @@ class OsmShortlinkTest {
             expected,
             OsmShortlink.parse("HTTPS://WWW.OPENSTREETMAP.ORG/go/0EEQjE--"),
         )
+        assertEquals(expected, OsmShortlink.parse("https://osm.org:443/go/0EEQjE--"))
     }
 
     @Test
@@ -84,6 +85,18 @@ class OsmShortlinkTest {
     }
 
     @Test
+    fun `wraps OpenStreetMap edges the way Rails does`() {
+        assertEquals(
+            OsmShortlink.of(Position(longitude = -180.0, latitude = 0.0), zoom = 9),
+            OsmShortlink.of(Position(longitude = 180.0, latitude = 0.0), zoom = 9),
+        )
+        assertEquals(
+            OsmShortlink.of(Position(longitude = 0.0, latitude = -90.0), zoom = 9),
+            OsmShortlink.of(Position(longitude = 0.0, latitude = 90.0), zoom = 9),
+        )
+    }
+
+    @Test
     fun `rejects invalid zoom coordinates codes and URLs`() {
         val origin = Position(longitude = 0.0, latitude = 0.0)
         assertFailsWith<IllegalArgumentException> { OsmShortlink.of(origin, zoom = -1) }
@@ -107,6 +120,8 @@ class OsmShortlinkTest {
                 "AAAAAAAAAAA",
                 "https://example.com/go/0EEQjE--",
                 "https://osm.org/map/0EEQjE--",
+                "https://osm.org:evil/go/0EEQjE--",
+                "https://osm.org:/go/0EEQjE--",
             )
             .forEach { text ->
                 assertFailsWith<IllegalArgumentException>(text) { OsmShortlink.parse(text) }

--- a/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/OsmShortlinkTest.kt
+++ b/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/OsmShortlinkTest.kt
@@ -132,6 +132,7 @@ class OsmShortlinkTest {
                 "https://osm.org/map/0EEQjE--",
                 "https://osm.org:evil/go/0EEQjE--",
                 "https://osm.org:/go/0EEQjE--",
+                "https://osm.org:\uFF11\uFF12/go/0EEQjE--",
             )
             .forEach { text ->
                 assertFailsWith<IllegalArgumentException>(text) { OsmShortlink.parse(text) }

--- a/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/SerializationTest.kt
+++ b/geohash/src/commonTest/kotlin/org/maplibre/spatialk/geohash/SerializationTest.kt
@@ -1,0 +1,38 @@
+package org.maplibre.spatialk.geohash
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class SerializationTest {
+    @Serializable private data class Holder(val cell: Geohash, val shortlink: OsmShortlink)
+
+    @Test
+    fun `round-trips cells and shortlinks as JSON strings`() {
+        val cell = Geohash.parse("ezs42")
+        val shortlink = OsmShortlink.parse("0EEQjE--")
+
+        assertEquals("\"ezs42\"", Json.encodeToString(cell))
+        assertEquals("\"0EEQjE--\"", Json.encodeToString(shortlink))
+        assertEquals(cell, Json.decodeFromString<Geohash>("\"EZS42\""))
+        assertEquals(shortlink, Json.decodeFromString<OsmShortlink>("\"0EEQjE--\""))
+
+        val holder = Holder(cell, shortlink)
+        val json = """{"cell":"ezs42","shortlink":"0EEQjE--"}"""
+        assertEquals(json, Json.encodeToString(holder))
+        assertEquals(holder, Json.decodeFromString<Holder>(json))
+    }
+
+    @Test
+    fun `rejects invalid JSON strings`() {
+        assertFailsWith<SerializationException> { Json.decodeFromString<Geohash>("\"ail\"") }
+        assertFailsWith<SerializationException> {
+            Json.decodeFromString<OsmShortlink>("\"ABC+--\"")
+        }
+    }
+}

--- a/geohash/src/commonTest/resources/README.md
+++ b/geohash/src/commonTest/resources/README.md
@@ -1,73 +1,64 @@
 # Geohash fixtures
 
-Checked-in vectors used by the geohash tests. Each JSON row has a `source` field. This file records
-where the suites came from and why they can live in this MIT repository.
+JSON used by the geohash tests. Every row has a `source` field.
 
-Coordinate order in these files is longitude, then latitude. Several upstream suites pass latitude
-first. The rows here are flipped to match Spatial K.
+Most of the libraries we pulled from pass latitude first. These files use longitude, then latitude,
+same as Spatial K.
 
-## Compatible copies
+## ngeohash
 
-### `ngeohash` (`sunng87/node-geohash`)
+MIT, Ning Sun. Their [LICENSE](https://github.com/sunng87/node-geohash/blob/master/LICENSE) has no
+copyright line. A copy is in `licenses/ngeohash-MIT.txt`.
 
-MIT. Author Ning Sun. Upstream
-[LICENSE](https://github.com/sunng87/node-geohash/blob/master/LICENSE) has no copyright line. A copy
-is in `licenses/ngeohash-MIT.txt`.
+Cases come from
+[`tests/test.js`](https://github.com/sunng87/node-geohash/blob/master/tests/test.js).
 
-Rows come from [`tests/test.js`](https://github.com/sunng87/node-geohash/blob/master/tests/test.js).
+Integer hashes, `ENCODE_AUTO`, hashes longer than 12 characters, and `bboxes` are out. We stop at
+`Geohash.MaxLength`, and we have no covering API.
 
-Skipped integer hashes, `ENCODE_AUTO`, hashes longer than 12 characters, and covering/`bboxes`.
-Those either exceed `Geohash.MaxLength` or test APIs this module does not have.
+## libgeohash
 
-### `libgeohash` (`simplegeo/libgeohash`)
+BSD-3-Clause, Copyright 2009 SimpleGeo. Their LICENSE forgot the copyright line that sits in the C
+headers. `licenses/libgeohash-BSD-3-Clause.txt` has both.
 
-BSD-3-Clause. Copyright 2009 SimpleGeo. The upstream LICENSE file omits the copyright line that
-appears in the C headers. `licenses/libgeohash-BSD-3-Clause.txt` keeps both.
-
-Rows come from
+Cases come from
 [`geohash_test.c`](https://github.com/simplegeo/libgeohash/blob/master/geohash_test.c).
 
-Skipped `geohash_encode(..., 0)`, which libgeohash treats as precision 6. This module requires an
-explicit length.
+`geohash_encode(..., 0)` is out. That call means precision 6 in libgeohash. We make you pass a
+length.
 
-### `mmcloughlin/geohash`
+## mmcloughlin/geohash
 
-MIT. Copyright 2015 Michael McLoughlin. Copy in `licenses/mmcloughlin-MIT.txt`.
+MIT, Copyright 2015 Michael McLoughlin. Copy in `licenses/mmcloughlin-MIT.txt`.
 
-Rows come from the named cases in
+Only the named cases in
 [`geohash_test.go`](https://github.com/mmcloughlin/geohash/blob/master/geohash_test.go)
-(`TestWikipediaExample`, `TestLeadingZero`).
+(`TestWikipediaExample`, `TestLeadingZero`). The generated `testcases_test.go` files are hundreds of
+kilobytes. Not worth the noise.
 
-The generated files `testcases_test.go`, `neighbors_testcases_test.go`, and `decodecases_test.go`
-were not imported.
+## Wikipedia
 
-## Facts and generated output
+`u4pruydqqvj` for `(10.40744, 57.64911)` is a published pair on
+<https://en.wikipedia.org/wiki/Geohash>. The row is that pair. None of the article.
 
-### Wikipedia Geohash article
+## OpenStreetMap shortlinks
 
-`u4pruydqqvj` at `(10.40744, 57.64911)` is a published coordinate and hash pair. The row records
-that pair only. It does not copy article prose.
+`openstreetmap-website` is GPL-2.0. Copying `short_link.rb` would put GPL code in an MIT tree, so
+none of that Ruby is here.
 
-<https://en.wikipedia.org/wiki/Geohash>
+`osm/encode.json` is numbers from the published encode algorithm, the wiki writeup plus the 32-bit
+wrap Rails uses. Those rows are what the algorithm printed. They are not Rails source.
 
-### OpenStreetMap shortlinks
-
-`openstreetmap-website` is GPL-2.0. None of its Ruby or test source is in this tree.
-
-`osm/encode.json` is output of the published encode algorithm (wiki description plus the 32-bit wrap
-used by OpenStreetMap Rails). Running a program to produce numbers is not a copy of that program.
-
-`osm/parse.json` uses shortlink codes from
+`osm/parse.json` uses codes from
 [the Shortlink wiki page](https://wiki.openstreetmap.org/wiki/Shortlink) (`0EEQjE--`, `0EEQjEEb`)
-and the documented historical `@` / `=` characters. Expected boxes for those codes were produced by
-the same published decode steps. `QQFq@mz--` is the `@` form of a generated code that contains `~`.
+and the old `@` / `=` characters. Boxes for those codes come from the same decode steps. `QQFq@mz--`
+is a generated `~` code with `@` swapped in.
 
 ## Files
 
-- `geohash/encode.json` — encode vectors from ngeohash, libgeohash, mmcloughlin, and the Wikipedia
-  pair
-- `geohash/decode.json` — ngeohash center check and libgeohash exact boxes
-- `geohash/neighbors.json` — full 8-neighbor maps from ngeohash and libgeohash
-- `geohash/neighbor_steps.json` — single-step ngeohash neighbor moves
-- `osm/encode.json` — generated OpenStreetMap shortlink encodings
-- `osm/parse.json` — wiki codes and historical character forms
+- `geohash/encode.json` from ngeohash, libgeohash, mmcloughlin, and the Wikipedia pair
+- `geohash/decode.json` from the ngeohash center check and the libgeohash boxes
+- `geohash/neighbors.json` from the 8-neighbor maps in ngeohash and libgeohash
+- `geohash/neighbor_steps.json` from the single-step ngeohash neighbor moves
+- `osm/encode.json` generated by the published shortlink encoder
+- `osm/parse.json` from the wiki codes and the historical character forms

--- a/geohash/src/commonTest/resources/README.md
+++ b/geohash/src/commonTest/resources/README.md
@@ -1,0 +1,73 @@
+# Geohash fixtures
+
+Checked-in vectors used by the geohash tests. Each JSON row has a `source` field. This file records
+where the suites came from and why they can live in this MIT repository.
+
+Coordinate order in these files is longitude, then latitude. Several upstream suites pass latitude
+first. The rows here are flipped to match Spatial K.
+
+## Compatible copies
+
+### `ngeohash` (`sunng87/node-geohash`)
+
+MIT. Author Ning Sun. Upstream
+[LICENSE](https://github.com/sunng87/node-geohash/blob/master/LICENSE) has no copyright line. A copy
+is in `licenses/ngeohash-MIT.txt`.
+
+Rows come from [`tests/test.js`](https://github.com/sunng87/node-geohash/blob/master/tests/test.js).
+
+Skipped integer hashes, `ENCODE_AUTO`, hashes longer than 12 characters, and covering/`bboxes`.
+Those either exceed `Geohash.MaxLength` or test APIs this module does not have.
+
+### `libgeohash` (`simplegeo/libgeohash`)
+
+BSD-3-Clause. Copyright 2009 SimpleGeo. The upstream LICENSE file omits the copyright line that
+appears in the C headers. `licenses/libgeohash-BSD-3-Clause.txt` keeps both.
+
+Rows come from
+[`geohash_test.c`](https://github.com/simplegeo/libgeohash/blob/master/geohash_test.c).
+
+Skipped `geohash_encode(..., 0)`, which libgeohash treats as precision 6. This module requires an
+explicit length.
+
+### `mmcloughlin/geohash`
+
+MIT. Copyright 2015 Michael McLoughlin. Copy in `licenses/mmcloughlin-MIT.txt`.
+
+Rows come from the named cases in
+[`geohash_test.go`](https://github.com/mmcloughlin/geohash/blob/master/geohash_test.go)
+(`TestWikipediaExample`, `TestLeadingZero`).
+
+The generated files `testcases_test.go`, `neighbors_testcases_test.go`, and `decodecases_test.go`
+were not imported.
+
+## Facts and generated output
+
+### Wikipedia Geohash article
+
+`u4pruydqqvj` at `(10.40744, 57.64911)` is a published coordinate and hash pair. The row records
+that pair only. It does not copy article prose.
+
+<https://en.wikipedia.org/wiki/Geohash>
+
+### OpenStreetMap shortlinks
+
+`openstreetmap-website` is GPL-2.0. None of its Ruby or test source is in this tree.
+
+`osm/encode.json` is output of the published encode algorithm (wiki description plus the 32-bit wrap
+used by OpenStreetMap Rails). Running a program to produce numbers is not a copy of that program.
+
+`osm/parse.json` uses shortlink codes from
+[the Shortlink wiki page](https://wiki.openstreetmap.org/wiki/Shortlink) (`0EEQjE--`, `0EEQjEEb`)
+and the documented historical `@` / `=` characters. Expected boxes for those codes were produced by
+the same published decode steps. `QQFq@mz--` is the `@` form of a generated code that contains `~`.
+
+## Files
+
+- `geohash/encode.json` — encode vectors from ngeohash, libgeohash, mmcloughlin, and the Wikipedia
+  pair
+- `geohash/decode.json` — ngeohash center check and libgeohash exact boxes
+- `geohash/neighbors.json` — full 8-neighbor maps from ngeohash and libgeohash
+- `geohash/neighbor_steps.json` — single-step ngeohash neighbor moves
+- `osm/encode.json` — generated OpenStreetMap shortlink encodings
+- `osm/parse.json` — wiki codes and historical character forms

--- a/geohash/src/commonTest/resources/geohash/decode.json
+++ b/geohash/src/commonTest/resources/geohash/decode.json
@@ -1,0 +1,33 @@
+[
+    { "source": "ngeohash", "text": "ww8p1r4t8", "longitude": 112.5584, "latitude": 37.8324 },
+    {
+        "source": "libgeohash",
+        "text": "ezs42",
+        "longitude": -5.60302734375,
+        "latitude": 42.60498046875,
+        "west": -5.625,
+        "south": 42.5830078125,
+        "east": -5.5810546875,
+        "north": 42.626953125
+    },
+    {
+        "source": "libgeohash",
+        "text": "ezs42gx",
+        "longitude": -5.5817413330078125,
+        "latitude": 42.602920532226562,
+        "west": -5.582427978515625,
+        "south": 42.60223388671875,
+        "east": -5.5810546875,
+        "north": 42.603607177734375
+    },
+    {
+        "source": "libgeohash",
+        "text": "9xj5smj4w40",
+        "longitude": -105.27485780417919,
+        "latitude": 40.018140748143196,
+        "west": -105.27485847473145,
+        "south": 40.018140077590942,
+        "east": -105.27485713362694,
+        "north": 40.01814141869545
+    }
+]

--- a/geohash/src/commonTest/resources/geohash/encode.json
+++ b/geohash/src/commonTest/resources/geohash/encode.json
@@ -1,0 +1,46 @@
+[
+    {
+        "source": "ngeohash",
+        "longitude": 112.5584,
+        "latitude": 37.8324,
+        "length": 9,
+        "text": "ww8p1r4t8"
+    },
+    { "source": "ngeohash", "longitude": 117.0, "latitude": 32.0, "length": 3, "text": "wte" },
+    {
+        "source": "libgeohash",
+        "longitude": -5.60302734375,
+        "latitude": 42.60498046875,
+        "length": 5,
+        "text": "ezs42"
+    },
+    {
+        "source": "libgeohash",
+        "longitude": -105.274858,
+        "latitude": 40.018141,
+        "length": 12,
+        "text": "9xj5smj4w40m"
+    },
+    {
+        "source": "libgeohash",
+        "longitude": -105.274858,
+        "latitude": 40.018141,
+        "length": 2,
+        "text": "9x"
+    },
+    { "source": "mmcloughlin", "longitude": -5.6, "latitude": 42.6, "length": 5, "text": "ezs42" },
+    {
+        "source": "mmcloughlin",
+        "longitude": -140.309714,
+        "latitude": -74.761330,
+        "length": 6,
+        "text": "0fsnxn"
+    },
+    {
+        "source": "wikipedia",
+        "longitude": 10.40744,
+        "latitude": 57.64911,
+        "length": 11,
+        "text": "u4pruydqqvj"
+    }
+]

--- a/geohash/src/commonTest/resources/geohash/neighbor_steps.json
+++ b/geohash/src/commonTest/resources/geohash/neighbor_steps.json
@@ -1,0 +1,8 @@
+[
+    { "source": "ngeohash", "text": "dqcjq", "east": 0, "north": 1, "expected": "dqcjw" },
+    { "source": "ngeohash", "text": "DQCJQ", "east": -1, "north": -1, "expected": "dqcjj" },
+    { "source": "ngeohash", "text": "r", "east": 1, "north": 1, "expected": "8" },
+    { "source": "ngeohash", "text": "r", "east": 1, "north": 0, "expected": "2" },
+    { "source": "ngeohash", "text": "r", "east": 1, "north": -1, "expected": "0" },
+    { "source": "ngeohash", "text": "j", "east": 0, "north": 1, "expected": "m" }
+]

--- a/geohash/src/commonTest/resources/geohash/neighbors.json
+++ b/geohash/src/commonTest/resources/geohash/neighbors.json
@@ -1,0 +1,62 @@
+[
+    {
+        "source": "ngeohash",
+        "text": "dqcjq",
+        "north": "dqcjw",
+        "northEast": "dqcjx",
+        "east": "dqcjr",
+        "southEast": "dqcjp",
+        "south": "dqcjn",
+        "southWest": "dqcjj",
+        "west": "dqcjm",
+        "northWest": "dqcjt"
+    },
+    {
+        "source": "ngeohash",
+        "text": "DQCJQ",
+        "north": "dqcjw",
+        "northEast": "dqcjx",
+        "east": "dqcjr",
+        "southEast": "dqcjp",
+        "south": "dqcjn",
+        "southWest": "dqcjj",
+        "west": "dqcjm",
+        "northWest": "dqcjt"
+    },
+    {
+        "source": "ngeohash",
+        "text": "21202",
+        "north": "21208",
+        "northEast": "21209",
+        "east": "21203",
+        "southEast": "21201",
+        "south": "21200",
+        "southWest": "rcrbp",
+        "west": "rcrbr",
+        "northWest": "rcrbx"
+    },
+    {
+        "source": "libgeohash",
+        "text": "ezs42",
+        "north": "ezs48",
+        "northEast": "ezs49",
+        "east": "ezs43",
+        "southEast": "ezs41",
+        "south": "ezs40",
+        "southWest": "ezefp",
+        "west": "ezefr",
+        "northWest": "ezefx"
+    },
+    {
+        "source": "libgeohash",
+        "text": "9xj5smj4w40m",
+        "north": "9xj5smj4w40q",
+        "northEast": "9xj5smj4w40w",
+        "east": "9xj5smj4w40t",
+        "southEast": "9xj5smj4w40s",
+        "south": "9xj5smj4w40k",
+        "southWest": "9xj5smj4w40h",
+        "west": "9xj5smj4w40j",
+        "northWest": "9xj5smj4w40n"
+    }
+]

--- a/geohash/src/commonTest/resources/licenses/libgeohash-BSD-3-Clause.txt
+++ b/geohash/src/commonTest/resources/licenses/libgeohash-BSD-3-Clause.txt
@@ -1,0 +1,22 @@
+Copyright 2009 SimpleGeo.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list
+of conditions and the following disclaimer. Redistributions in binary form must
+reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the distribution.
+Neither the name of the SimpleGeo nor the names of its contributors may be used
+to endorse or promote products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/geohash/src/commonTest/resources/licenses/mmcloughlin-MIT.txt
+++ b/geohash/src/commonTest/resources/licenses/mmcloughlin-MIT.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Michael McLoughlin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/geohash/src/commonTest/resources/licenses/ngeohash-MIT.txt
+++ b/geohash/src/commonTest/resources/licenses/ngeohash-MIT.txt
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/geohash/src/commonTest/resources/osm/encode.json
+++ b/geohash/src/commonTest/resources/osm/encode.json
@@ -1,0 +1,154 @@
+[
+    {
+        "name": "london-rails",
+        "longitude": 0.054,
+        "latitude": 51.51,
+        "zoom": 9,
+        "text": "0EEQhq--"
+    },
+    {
+        "name": "london-rails-z0",
+        "longitude": 0.054,
+        "latitude": 51.51,
+        "zoom": 0,
+        "text": "0EE--"
+    },
+    {
+        "name": "london-rails-z8",
+        "longitude": 0.054,
+        "latitude": 51.51,
+        "zoom": 8,
+        "text": "0EEQhq-"
+    },
+    {
+        "name": "london-rails-z10",
+        "longitude": 0.054,
+        "latitude": 51.51,
+        "zoom": 10,
+        "text": "0EEQhq"
+    },
+    {
+        "name": "london-rails-z22",
+        "longitude": 0.054,
+        "latitude": 51.51,
+        "zoom": 22,
+        "text": "0EEQhqc112"
+    },
+    {
+        "name": "new-york",
+        "longitude": -74.006,
+        "latitude": 40.7128,
+        "zoom": 9,
+        "text": "Zct2v4--"
+    },
+    { "name": "tokyo", "longitude": 139.6917, "latitude": 35.6895, "zoom": 9, "text": "7Q5yLA--" },
+    {
+        "name": "sydney",
+        "longitude": 151.2093,
+        "latitude": -33.8688,
+        "zoom": 9,
+        "text": "uN~ROO--"
+    },
+    {
+        "name": "sao-paulo",
+        "longitude": -46.6333,
+        "latitude": -23.5505,
+        "zoom": 9,
+        "text": "M~ziKc--"
+    },
+    { "name": "origin-z0", "longitude": 0.0, "latitude": 0.0, "zoom": 0, "text": "wAA--" },
+    { "name": "origin-z1", "longitude": 0.0, "latitude": 0.0, "zoom": 1, "text": "wAA" },
+    { "name": "origin-z2", "longitude": 0.0, "latitude": 0.0, "zoom": 2, "text": "wAAA-" },
+    { "name": "origin-z3", "longitude": 0.0, "latitude": 0.0, "zoom": 3, "text": "wAAA--" },
+    { "name": "origin-z4", "longitude": 0.0, "latitude": 0.0, "zoom": 4, "text": "wAAA" },
+    { "name": "origin-z5", "longitude": 0.0, "latitude": 0.0, "zoom": 5, "text": "wAAAA-" },
+    { "name": "origin-z6", "longitude": 0.0, "latitude": 0.0, "zoom": 6, "text": "wAAAA--" },
+    { "name": "origin-z7", "longitude": 0.0, "latitude": 0.0, "zoom": 7, "text": "wAAAA" },
+    { "name": "origin-z8", "longitude": 0.0, "latitude": 0.0, "zoom": 8, "text": "wAAAAA-" },
+    { "name": "origin-z9", "longitude": 0.0, "latitude": 0.0, "zoom": 9, "text": "wAAAAA--" },
+    { "name": "origin-z10", "longitude": 0.0, "latitude": 0.0, "zoom": 10, "text": "wAAAAA" },
+    { "name": "origin-z11", "longitude": 0.0, "latitude": 0.0, "zoom": 11, "text": "wAAAAAA-" },
+    { "name": "origin-z12", "longitude": 0.0, "latitude": 0.0, "zoom": 12, "text": "wAAAAAA--" },
+    { "name": "origin-z13", "longitude": 0.0, "latitude": 0.0, "zoom": 13, "text": "wAAAAAA" },
+    { "name": "origin-z14", "longitude": 0.0, "latitude": 0.0, "zoom": 14, "text": "wAAAAAAA-" },
+    { "name": "origin-z15", "longitude": 0.0, "latitude": 0.0, "zoom": 15, "text": "wAAAAAAA--" },
+    { "name": "origin-z16", "longitude": 0.0, "latitude": 0.0, "zoom": 16, "text": "wAAAAAAA" },
+    { "name": "origin-z17", "longitude": 0.0, "latitude": 0.0, "zoom": 17, "text": "wAAAAAAAA-" },
+    { "name": "origin-z18", "longitude": 0.0, "latitude": 0.0, "zoom": 18, "text": "wAAAAAAAA--" },
+    { "name": "origin-z19", "longitude": 0.0, "latitude": 0.0, "zoom": 19, "text": "wAAAAAAAA" },
+    { "name": "origin-z20", "longitude": 0.0, "latitude": 0.0, "zoom": 20, "text": "wAAAAAAAAA-" },
+    { "name": "origin-z21", "longitude": 0.0, "latitude": 0.0, "zoom": 21, "text": "wAAAAAAAAA--" },
+    { "name": "origin-z22", "longitude": 0.0, "latitude": 0.0, "zoom": 22, "text": "wAAAAAAAAA" },
+    {
+        "name": "east-antimeridian-z9",
+        "longitude": 180.0,
+        "latitude": 0.0,
+        "zoom": 9,
+        "text": "QAAAAA--"
+    },
+    {
+        "name": "west-antimeridian-z9",
+        "longitude": -180.0,
+        "latitude": 0.0,
+        "zoom": 9,
+        "text": "QAAAAA--"
+    },
+    { "name": "north-pole-z9", "longitude": 0.0, "latitude": 90.0, "zoom": 9, "text": "gAAAAA--" },
+    { "name": "south-pole-z9", "longitude": 0.0, "latitude": -90.0, "zoom": 9, "text": "gAAAAA--" },
+    {
+        "name": "northeast-corner-z9",
+        "longitude": 180.0,
+        "latitude": 90.0,
+        "zoom": 9,
+        "text": "AAAAAA--"
+    },
+    {
+        "name": "southwest-corner-z9",
+        "longitude": -180.0,
+        "latitude": -90.0,
+        "zoom": 9,
+        "text": "AAAAAA--"
+    },
+    {
+        "name": "east-antimeridian-z22",
+        "longitude": 180.0,
+        "latitude": 0.0,
+        "zoom": 22,
+        "text": "QAAAAAAAAA"
+    },
+    {
+        "name": "west-antimeridian-z22",
+        "longitude": -180.0,
+        "latitude": 0.0,
+        "zoom": 22,
+        "text": "QAAAAAAAAA"
+    },
+    {
+        "name": "north-pole-z22",
+        "longitude": 0.0,
+        "latitude": 90.0,
+        "zoom": 22,
+        "text": "gAAAAAAAAA"
+    },
+    {
+        "name": "south-pole-z22",
+        "longitude": 0.0,
+        "latitude": -90.0,
+        "zoom": 22,
+        "text": "gAAAAAAAAA"
+    },
+    {
+        "name": "northeast-corner-z22",
+        "longitude": 180.0,
+        "latitude": 90.0,
+        "zoom": 22,
+        "text": "AAAAAAAAAA"
+    },
+    {
+        "name": "southwest-corner-z22",
+        "longitude": -180.0,
+        "latitude": -90.0,
+        "zoom": 22,
+        "text": "AAAAAAAAAA"
+    }
+]

--- a/geohash/src/commonTest/resources/osm/parse.json
+++ b/geohash/src/commonTest/resources/osm/parse.json
@@ -1,0 +1,40 @@
+[
+    {
+        "source": "osm-wiki",
+        "input": "0EEQjE--",
+        "text": "0EEQjE--",
+        "zoom": 9,
+        "longitude": 0.0556182861328125,
+        "latitude": 51.51111602783203,
+        "west": 0.054931640625,
+        "south": 51.510772705078125,
+        "east": 0.056304931640625,
+        "north": 51.51145935058594
+    },
+    {
+        "source": "osm-wiki",
+        "input": "https://osm.org/go/0EEQjE--",
+        "text": "0EEQjE--",
+        "zoom": 9,
+        "longitude": 0.0556182861328125,
+        "latitude": 51.51111602783203,
+        "west": 0.054931640625,
+        "south": 51.510772705078125,
+        "east": 0.056304931640625,
+        "north": 51.51145935058594
+    },
+    {
+        "source": "osm-wiki",
+        "input": "https://osm.org/go/0EEQjEEb",
+        "text": "0EEQjEEb",
+        "zoom": 16,
+        "longitude": 0.05500674247741699,
+        "latitude": 51.511003375053406,
+        "west": 0.05499601364135742,
+        "south": 51.510998010635376,
+        "east": 0.05501747131347656,
+        "north": 51.511008739471436
+    },
+    { "source": "osm-wiki-history", "input": "0EEQjE==", "text": "0EEQjE--" },
+    { "source": "generated", "input": "QQFq@mz--", "text": "QQFq~mz--" }
+]

--- a/geohash/src/jvmTest/java/org/maplibre/spatialk/geohash/JavaDocsTest.java
+++ b/geohash/src/jvmTest/java/org/maplibre/spatialk/geohash/JavaDocsTest.java
@@ -1,0 +1,29 @@
+package org.maplibre.spatialk.geohash;
+
+import org.junit.Test;
+import org.maplibre.spatialk.geojson.BoundingBox;
+import org.maplibre.spatialk.geojson.Position;
+
+@SuppressWarnings("unused")
+public class JavaDocsTest {
+  @Test
+  public void staticFactoriesAndCellProperties() {
+    Position position = new Position(10.40744, 57.64911);
+    Geohash encoded = Geohash.of(position, 11);
+    Geohash parsed = Geohash.parse("u4pruydqqvj");
+    Geohash nullable = Geohash.parseOrNull("U4PRUYDQQVJ");
+
+    String text = parsed.getText();
+    BoundingBox boundingBox = parsed.getBoundingBox();
+    GeohashNeighbors neighbors = parsed.getNeighbors();
+    Geohash east = neighbors.getEast();
+    Geohash offset = parsed.offsetBy(1, 0);
+  }
+
+  @Test
+  public void shortlinkStaticFactories() {
+    OsmShortlink encoded = OsmShortlink.of(new Position(0.054, 51.510), 9);
+    OsmShortlink parsed = OsmShortlink.parse("https://osm.org/go/0EEQjE--");
+    OsmShortlink nullable = OsmShortlink.parseOrNull("0EEQjE--");
+  }
+}

--- a/geohash/src/jvmTest/java/org/maplibre/spatialk/geohash/JavaDocsTest.java
+++ b/geohash/src/jvmTest/java/org/maplibre/spatialk/geohash/JavaDocsTest.java
@@ -18,6 +18,7 @@ public class JavaDocsTest {
     GeohashNeighbors neighbors = parsed.getNeighbors();
     Geohash east = neighbors.getEast();
     Geohash offset = parsed.offsetBy(1, 0);
+    java.util.List<Geohash> children = parsed.getChildren();
   }
 
   @Test

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,4 +24,5 @@ include(
     ":benchmark",
     ":polyline-encoding",
     ":pmtiles",
+    ":geohash",
 )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a published [`geohash`](https://en.wikipedia.org/wiki/Geohash) module. `OsmShortlink` is a sibling type for OSM `/go/` codes. Both types serialize as their canonical strings. Docs, ABI dumps, and root Gradle wiring are included.

Imported encode, decode, and neighbor vectors now live under `geohash/src/commonTest/resources` with license copies and a provenance README. OSM encode rows are generated from the published shortlink algorithm, not copied from GPL Rails source.

Resolve #363

## Test plan

- `mise exec -- ./gradlew :geohash:jvmTest`
- `SPATIAL_K_VERSION=dev pnpm --filter docs exec astro build`

## AI assistance

- **Tools:** Cursor
- **Models:** Cursor Grok 4.6, Claude Fable, GPT-5.6, Claude Opus (pstack)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4ad7596-a44d-4b93-aa7b-700023849d76?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4ad7596-a44d-4b93-aa7b-700023849d76&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

